### PR TITLE
Fix dashboard-setup-startup-hook

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -155,10 +155,10 @@ If a command line argument is provided, assume a filename and skip displaying Da
 	(add-hook 'after-init-hook (lambda ()
 				     ;; Display useful lists of items
 				     (dashboard-insert-startupify-lists)))
-	(add-hook 'emacs-startup-hook '(lambda ()
-					 (switch-to-buffer "*dashboard*")
-					 (goto-char (point-min))
-					 (redisplay))))))
+	(add-hook 'window-setup-hook '(lambda ()
+                                        (switch-to-buffer "*dashboard*")
+                                        (goto-char (point-min))
+                                        (redisplay))))))
 
 (provide 'dashboard)
 ;;; dashboard.el ends here


### PR DESCRIPTION
Hooks from `emacs-startup-hook` are called too early so dashboard
incorrectly drawn text version of logo on some occasions. Steps to
reproduce:

* Start `emacs --daemon` from terminal
* Open `emacsclient -t`
* Open `emacsclient -c` -- text version of logo is displayed

This behavior is fixed by utilizing `window-setup-hook`. Emacs'
documentation of `window-setup-hook`:

This normal hook is very similar to emacs-startup-hook. The only
difference is that it runs slightly later, after setting of the frame
parameters.