### PR TITLE
Feature/center content

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,13 +59,14 @@ To update the banner or banner title
 (setq dashboard-banner-logo-title "Welcome to Emacs Dashboard")
 ;; Set the banner
 (setq dashboard-startup-banner [VALUE])
-;; Content is centered by default. To left-justify, set
-(setq dashboard-center-content nil)
 ;; Value can be
 ;; 'official which displays the official emacs logo
 ;; 'logo which displays an alternative emacs logo
 ;; 1, 2 or 3 which displays one of the text banners
 ;; "path/to/your/image.png" which displays whatever image you would prefer
+
+;; Content is centered by default. To left-justify, set
+(setq dashboard-center-content nil)
 #+END_SRC
 
 To customize which widgets are displayed, you can use the following snippet

--- a/README.org
+++ b/README.org
@@ -59,6 +59,8 @@ To update the banner or banner title
 (setq dashboard-banner-logo-title "Welcome to Emacs Dashboard")
 ;; Set the banner
 (setq dashboard-startup-banner [VALUE])
+;; Content is centered by default. To left-justify, set
+(setq dashboard-center-content nil)
 ;; Value can be
 ;; 'official which displays the official emacs logo
 ;; 'logo which displays an alternative emacs logo

--- a/README.org
+++ b/README.org
@@ -66,7 +66,7 @@ To update the banner or banner title
 ;; 1, 2 or 3 which displays one of the text banners
 ;; "path/to/your/image.png" which displays whatever image you would prefer
 
-;; Content is centered by default. To left-justify, set
+;; Content is not centered by default. To center, set
 (setq dashboard-center-content nil)
 #+END_SRC
 

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -287,7 +287,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
    recentf-list
    list-size
    "r"
-   (lambda (&rest ignore) (find-file-existing el))
+   `(lambda (&rest ignore) (find-file-existing ,el))
    (abbreviate-file-name el)))
 
 ;;
@@ -302,7 +302,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
                      0 list-size)
    list-size
    "m"
-   (lambda (&rest ignore) (bookmark-jump el))
+   `(lambda (&rest ignore) (bookmark-jump ,el))
    (let ((file (bookmark-get-filename el)))
      (if file
          (format "%s - %s" el (abbreviate-file-name file))
@@ -323,7 +323,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
                            0 list-size)
          list-size
          "p"
-         (lambda (&rest ignore) (projectile-switch-project-by-name el))
+         `(lambda (&rest ignore) (projectile-switch-project-by-name ,el))
          (abbreviate-file-name el)))))
 
 ;;
@@ -396,11 +396,11 @@ date part is considered."
      (or agenda '())
      list-size
      "a"
-     (lambda (&rest ignore)
-       (let ((buffer (find-file-other-window (nth 4 el))))
-         (with-current-buffer buffer
-           (goto-char (nth 3 el)))
-         (switch-to-buffer buffer)))
+     `(lambda (&rest ignore)
+        (let ((buffer (find-file-other-window (nth 4 ,el))))
+          (with-current-buffer buffer
+            (goto-char (nth 3 ,el)))
+          (switch-to-buffer buffer)))
      (format "%s" (nth 0 el)))
     (and (not agenda)
          (insert "\n    --- No items ---"))))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -228,25 +228,25 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 ;; Section insertion
 ;;
 (defmacro dashboard-insert-section-list (section-name list action &rest rest)
-	"Insert a LIST of items with SECTION-NAME, expanding ACTION and passing REST to widget creation."
-	`(let ((max-line-length 0))
-		 (when (car ,list)
-			 (mapc (lambda (el)
-							 (let ((widget nil))
-								 (insert "\n    ")
-								 (setq widget
-											 (widget-create 'push-button
-																			:action ,action
-																			:mouse-face 'highlight
-																			:follow-link "\C-m"
-																			:button-prefix ""
-																			:button-suffix ""
-																			:format "%[%t%]"
-																			,@rest))
-								 (setq max-line-length
-											 (max max-line-length (length (widget-value-value-get widget))))))
-						 ,list))
-		 max-line-length))
+  "Insert a LIST of items with SECTION-NAME, expanding ACTION and passing REST to widget creation."
+  `(let ((max-line-length 0))
+     (when (car ,list)
+       (mapc (lambda (el)
+               (let ((widget nil))
+                 (insert "\n    ")
+                 (setq widget
+                       (widget-create 'push-button
+                                      :action ,action
+                                      :mouse-face 'highlight
+                                      :follow-link "\C-m"
+                                      :button-prefix ""
+                                      :button-suffix ""
+                                      :format "%[%t%]"
+                                      ,@rest))
+                 (setq max-line-length
+                       (max max-line-length (length (widget-value-value-get widget))))))
+             ,list))
+     max-line-length))
 
 (defmacro dashboard-insert-section (section-name list list-size shortcut action &rest widget-params)
   "Add a section with SECTION-NAME and LIST of LIST-SIZE items to the dashboard.
@@ -254,16 +254,16 @@ ACTION is theaction taken when the user activates the widget button.
 SHORTCUT is the keyboard shortcut used to access the section.
 WIDGET-PARAMS are passed to the \"widget-create\" function.
 Show EMPTY-LIST-TEXT if no items in list"
-	`(progn
-		 (dashboard-insert-heading ,section-name)
-		 (when-let ((max-line-length
-								 (dashboard-insert-section-list
-									,section-name
-									(dashboard-subseq ,list 0 list-size)
-									,action
-									,@widget-params)))
-			 (dashboard-insert-shortcut ,shortcut ,section-name)
-			 max-line-length)))
+  `(progn
+     (dashboard-insert-heading ,section-name)
+     (when-let ((max-line-length
+                 (dashboard-insert-section-list
+                  ,section-name
+                  (dashboard-subseq ,list 0 list-size)
+                  ,action
+                  ,@widget-params)))
+       (dashboard-insert-shortcut ,shortcut ,section-name)
+       max-line-length)))
 
 ;;
 ;; Recentf
@@ -271,13 +271,13 @@ Show EMPTY-LIST-TEXT if no items in list"
 (defun dashboard-insert-recents (list-size)
   "Add the list of LIST-SIZE items from recently edited files."
   (recentf-mode)
-	(dashboard-insert-section
-	 "Recent Files:"
-	 recentf-list
-	 list-size
-	 "r"
-	 `(lambda (&rest ignore) (find-file-existing ,el))
-	 (abbreviate-file-name el)))
+  (dashboard-insert-section
+   "Recent Files:"
+   recentf-list
+   list-size
+   "r"
+   `(lambda (&rest ignore) (find-file-existing ,el))
+   (abbreviate-file-name el)))
 
 ;;
 ;; Bookmarks
@@ -286,35 +286,35 @@ Show EMPTY-LIST-TEXT if no items in list"
   "Add the list of LIST-SIZE items of bookmarks."
   (require 'bookmark)
   (dashboard-insert-section
-	 "Bookmarks:"
-	 (dashboard-subseq (bookmark-all-names)
-																 0 list-size)
-	 list-size
-	 "m"
-	 `(lambda (&rest ignore) (bookmark-jump ,el))
-	 (let ((file (bookmark-get-filename el)))
-								 (if file
-										 (format "%s - %s" el (abbreviate-file-name file))
-									 el))))
+   "Bookmarks:"
+   (dashboard-subseq (bookmark-all-names)
+                                 0 list-size)
+   list-size
+   "m"
+   `(lambda (&rest ignore) (bookmark-jump ,el))
+   (let ((file (bookmark-get-filename el)))
+                 (if file
+                     (format "%s - %s" el (abbreviate-file-name file))
+                   el))))
 
 ;;
 ;; Projectile
 ;;
 (defun dashboard-insert-projects (list-size)
   "Add the list of LIST-SIZE items of projects."
-	(projectile-mode)
-	(if (bound-and-true-p projectile-mode)
-			(progn
-				(projectile-load-known-projects)
-				(dashboard-insert-section
-				 "Projects:"
-				 (dashboard-subseq (projectile-relevant-known-projects)
-													 0 list-size)
-				 list-size
-				 "p"
-				 `(lambda (&rest ignore)
-						(projectile-switch-project-by-name ,el))
-				 (abbreviate-file-name el)))))
+  (projectile-mode)
+  (if (bound-and-true-p projectile-mode)
+      (progn
+        (projectile-load-known-projects)
+        (dashboard-insert-section
+         "Projects:"
+         (dashboard-subseq (projectile-relevant-known-projects)
+                           0 list-size)
+         list-size
+         "p"
+         `(lambda (&rest ignore)
+            (projectile-switch-project-by-name ,el))
+         (abbreviate-file-name el)))))
 
 ;;
 ;; Org Agenda
@@ -377,22 +377,22 @@ date part is considered."
     filtered-entries))
 
 (defun dashboard-insert-agenda (list-size)
-	"Add the list of LIST-SIZE items of agenda."
-	(let ((agenda (dashboard-get-agenda)))
-		(dashboard-insert-section
-		 (or (and (boundp 'show-week-agenda-p) show-week-agenda-p "Agenda for the coming week:")
-				 "Agenda for today:")
-		 (or agenda '())
-		 list-size
-		 "a"
-		 `(lambda (&rest ignore)
-				(let ((buffer (find-file-other-window (nth 4 el))))
-					(with-current-buffer buffer
-						(goto-char (nth 3 el)))
-					(switch-to-buffer buffer)))
-		 (format "%s" (nth 0 el)))
-		(and (not agenda)
-				 (insert "\n    --- No items ---"))))
+  "Add the list of LIST-SIZE items of agenda."
+  (let ((agenda (dashboard-get-agenda)))
+    (dashboard-insert-section
+     (or (and (boundp 'show-week-agenda-p) show-week-agenda-p "Agenda for the coming week:")
+         "Agenda for today:")
+     (or agenda '())
+     list-size
+     "a"
+     `(lambda (&rest ignore)
+        (let ((buffer (find-file-other-window (nth 4 el))))
+          (with-current-buffer buffer
+            (goto-char (nth 3 el)))
+          (switch-to-buffer buffer)))
+     (format "%s" (nth 0 el)))
+    (and (not agenda)
+         (insert "\n    --- No items ---"))))
 
 ;;
 ;; Registers
@@ -400,13 +400,13 @@ date part is considered."
 (defun dashboard-insert-registers (list-size)
   "Add the list of LIST-SIZE items of registers."
   (require 'register)
-	(dashboard-insert-section
-	 "Registers:"
-	 register-alist
-	 list-size
-	 "e"
-	 `(lambda (&rest ignore) (jump-to-register ,(car el)))
-	 (format "%c - %s" (car el) (register-describe-oneline (car el)))))
+  (dashboard-insert-section
+   "Registers:"
+   register-alist
+   list-size
+   "e"
+   `(lambda (&rest ignore) (jump-to-register ,(car el)))
+   (format "%c - %s" (car el) (register-describe-oneline (car el)))))
 
 
 ;; Forward declartions for optional dependency to keep check-declare happy.

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -273,8 +273,8 @@ Show EMPTY-LIST-TEXT if no items in list"
                   (dashboard-subseq ,list 0 list-size)
                   ,action
                   ,@widget-params)))
-       (dashboard-insert-shortcut ,shortcut ,section-name)
-       max-line-length)))
+               (dashboard-insert-shortcut ,shortcut ,section-name)
+               max-line-length)))
 
 ;;
 ;; Recentf
@@ -299,14 +299,14 @@ Show EMPTY-LIST-TEXT if no items in list"
   (dashboard-insert-section
    "Bookmarks:"
    (dashboard-subseq (bookmark-all-names)
-                                 0 list-size)
+                     0 list-size)
    list-size
    "m"
    `(lambda (&rest ignore) (bookmark-jump ,el))
    (let ((file (bookmark-get-filename el)))
-                 (if file
-                     (format "%s - %s" el (abbreviate-file-name file))
-                   el))))
+     (if file
+         (format "%s - %s" el (abbreviate-file-name file))
+       el))))
 
 ;;
 ;; Projectile

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -42,8 +42,8 @@ to the specified width, with aspect ratio preserved."
 
 (defconst dashboard-banners-directory
   (concat (file-name-directory
-					 (locate-library "dashboard"))
-					"/banners/"))
+	   (locate-library "dashboard"))
+	   "/banners/"))
 
 (defconst dashboard-banner-official-png
   (expand-file-name (concat dashboard-banners-directory "emacs.png"))
@@ -57,10 +57,10 @@ to the specified width, with aspect ratio preserved."
   "Width of a banner.")
 
 (defvar dashboard-banner-logo-title "Welcome to Emacs!"
-  "Specify the startup banner.")
+   "Specify the startup banner.")
 
 (defvar dashboard-startup-banner 'official
-  "Specify the startup banner.
+   "Specify the startup banner.
 Default value is `official', it displays
 the Emacs logo.  `logo' displays Emacs alternative logo.
 An integer value is the index of text
@@ -112,17 +112,17 @@ Return entire list if `END' is omitted."
                               (min len end)))))
 
 (defmacro dashboard-insert-shortcut (shortcut-char
-																		 search-label
-																		 &optional no-next-line)
+				      search-label
+				      &optional no-next-line)
   "Insert a shortcut SHORTCUT-CHAR for a given SEARCH-LABEL.
 Optionally, provide NO-NEXT-LINE to move the cursor forward a line."
   `(define-key dashboard-mode-map ,shortcut-char (lambda ()
-																									 (interactive)
-																									 (unless (search-forward ,search-label (point-max) t)
-																										 (search-backward ,search-label (point-min) t))
-																									 ,@(unless no-next-line
-																											 '((forward-line 1)))
-																									 (back-to-indentation))))
+			       (interactive)
+			       (unless (search-forward ,search-label (point-max) t)
+				 (search-backward ,search-label (point-min) t))
+			       ,@(unless no-next-line
+				   '((forward-line 1)))
+			       (back-to-indentation))))
 
 (defun dashboard-append (msg &optional messagebuf)
   "Append MSG to dashboard buffer.
@@ -157,7 +157,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
        (goto-char 0)
        (let ((margin (max 0 (floor (/ (- dashboard-banner-length banner-width) 2)))))
          (while (not (eobp))
-					 (insert (make-string margin ?\ ))
+	   (insert (make-string margin ?\ ))
            (forward-line 1))))
      (buffer-string))))
 
@@ -181,9 +181,9 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
       (insert-image spec)
       (insert "\n\n")
       (when title
-				(insert (make-string (max 0 (floor (/ (- dashboard-banner-length
-																								 (+ (length title) 1)) 2))) ?\ ))
-				(insert (format "%s\n\n" (propertize title 'face 'dashboard-banner-logo-title-face)))))))
+	(insert (make-string (max 0 (floor (/ (- dashboard-banner-length
+						 (+ (length title) 1)) 2))) ?\ ))
+	(insert (format "%s\n\n" (propertize title 'face 'dashboard-banner-logo-title-face)))))))
 
 (defun dashboard-get-banner-path (index)
   "Return the full path to banner with index INDEX."
@@ -196,7 +196,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
            (if (and (display-graphic-p) (image-type-available-p 'png))
                dashboard-banner-official-png
              (dashboard-get-banner-path 1)))
-					((eq 'logo dashboard-startup-banner)
+	  ((eq 'logo dashboard-startup-banner)
            (if (and (display-graphic-p) (image-type-available-p 'png))
                dashboard-banner-logo-png
              (dashboard-get-banner-path 1)))
@@ -208,9 +208,9 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                 (display-graphic-p))
            (if (file-exists-p dashboard-startup-banner)
                dashboard-startup-banner
-						 (message (format "could not find banner %s"
-															dashboard-startup-banner))
-						 (dashboard-get-banner-path 1)))
+	     (message (format "could not find banner %s"
+			      dashboard-startup-banner))
+	     (dashboard-get-banner-path 1)))
           (t (dashboard-get-banner-path 1)))))
 
 (defun dashboard-insert-banner ()
@@ -220,7 +220,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
         (buffer-read-only nil))
     (progn
       (when banner
-				(if (image-type-available-p (intern (file-name-extension banner)))
+	(if (image-type-available-p (intern (file-name-extension banner)))
             (dashboard-insert-image-banner banner)
           (dashboard-insert-ascii-banner-centered banner))))))
 
@@ -356,16 +356,16 @@ date part is considered."
     (org-map-entries
      (lambda ()
        (let* ((schedule-time (org-get-scheduled-time (point)))
-							(deadline-time (org-get-deadline-time (point)))
-							(item (org-agenda-format-item
-										 (format-time-string "%Y-%m-%d" schedule-time)
-                     (org-get-heading t t)
-                     (org-outline-level)
-                     (org-get-category)
-                     (org-get-tags)
-                     t))
-							(loc (point))
-							(file (buffer-file-name)))
+             (deadline-time (org-get-deadline-time (point)))
+             (item (org-agenda-format-item
+		    (format-time-string "%Y-%m-%d" schedule-time)
+                    (org-get-heading t t)
+                    (org-outline-level)
+                    (org-get-category)
+                    (org-get-tags)
+                    t))
+             (loc (point))
+             (file (buffer-file-name)))
          (when (and (not (org-entry-is-done-p))
                     (or (and schedule-time (dashboard-date-due-p schedule-time due-date))
                         (and deadline-time (dashboard-date-due-p deadline-time due-date))))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -240,24 +240,20 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 ;;
 (defmacro dashboard-insert-section-list (section-name list action &rest rest)
   "Insert into SECTION-NAME a LIST of items, expanding ACTION and passing REST to widget creation."
-  `(let ((max-line-length 0))
-     (when (car ,list)
-       (mapc (lambda (el)
-               (let ((widget nil))
-                 (insert "\n    ")
-                 (setq widget
-                       (widget-create 'push-button
-                                      :action ,action
-                                      :mouse-face 'highlight
-                                      :follow-link "\C-m"
-                                      :button-prefix ""
-                                      :button-suffix ""
-                                      :format "%[%t%]"
-                                      ,@rest))
-                 (setq max-line-length
-                       (max max-line-length (length (widget-get widget :value))))))
-             ,list))
-     max-line-length))
+  `(when (car ,list)
+     (mapc (lambda (el)
+             (let ((widget nil))
+               (insert "\n    ")
+               (setq widget
+                     (widget-create 'push-button
+                                    :action ,action
+                                    :mouse-face 'highlight
+                                    :follow-link "\C-m"
+                                    :button-prefix ""
+                                    :button-suffix ""
+                                    :format "%[%t%]"
+                                    ,@rest))))
+           ,list)))
 
 (defmacro dashboard-insert-section (section-name list list-size shortcut action &rest widget-params)
   "Add a section with SECTION-NAME and LIST of LIST-SIZE items to the dashboard.
@@ -266,15 +262,12 @@ ACTION is theaction taken when the user activates the widget button.
 WIDGET-PARAMS are passed to the \"widget-create\" function."
   `(progn
      (dashboard-insert-heading ,section-name)
-     (let ((max-line-length (dashboard-insert-section-list
-                             ,section-name
-                             (dashboard-subseq ,list 0 list-size)
-                             ,action
-                             ,@widget-params)))
-       (if max-line-length
-           (progn
-             (dashboard-insert-shortcut ,shortcut ,section-name)
-             max-line-length)))))
+     (when (dashboard-insert-section-list
+            ,section-name
+            (dashboard-subseq ,list 0 list-size)
+            ,action
+            ,@widget-params)
+       (dashboard-insert-shortcut ,shortcut ,section-name))))
 
 ;;
 ;; Recentf

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -1,4 +1,4 @@
-;;; dashboard.el --- A startup screen extracted from Spacemacs
+;;; dashboard-widgets.el --- A startup screen extracted from Spacemacs
 
 ;; Copyright (c) 2016 Rakan Al-Hneiti & Contributors
 ;;
@@ -42,8 +42,8 @@ to the specified width, with aspect ratio preserved."
 
 (defconst dashboard-banners-directory
   (concat (file-name-directory
-	   (locate-library "dashboard"))
-	   "/banners/"))
+					 (locate-library "dashboard"))
+					"/banners/"))
 
 (defconst dashboard-banner-official-png
   (expand-file-name (concat dashboard-banners-directory "emacs.png"))
@@ -57,10 +57,10 @@ to the specified width, with aspect ratio preserved."
   "Width of a banner.")
 
 (defvar dashboard-banner-logo-title "Welcome to Emacs!"
-   "Specify the startup banner.")
+  "Specify the startup banner.")
 
 (defvar dashboard-startup-banner 'official
-   "Specify the startup banner.
+  "Specify the startup banner.
 Default value is `official', it displays
 the Emacs logo.  `logo' displays Emacs alternative logo.
 An integer value is the index of text
@@ -112,17 +112,17 @@ Return entire list if `END' is omitted."
                               (min len end)))))
 
 (defmacro dashboard-insert-shortcut (shortcut-char
-				      search-label
-				      &optional no-next-line)
+																		 search-label
+																		 &optional no-next-line)
   "Insert a shortcut SHORTCUT-CHAR for a given SEARCH-LABEL.
 Optionally, provide NO-NEXT-LINE to move the cursor forward a line."
   `(define-key dashboard-mode-map ,shortcut-char (lambda ()
-			       (interactive)
-			       (unless (search-forward ,search-label (point-max) t)
-				 (search-backward ,search-label (point-min) t))
-			       ,@(unless no-next-line
-				   '((forward-line 1)))
-			       (back-to-indentation))))
+																									 (interactive)
+																									 (unless (search-forward ,search-label (point-max) t)
+																										 (search-backward ,search-label (point-min) t))
+																									 ,@(unless no-next-line
+																											 '((forward-line 1)))
+																									 (back-to-indentation))))
 
 (defun dashboard-append (msg &optional messagebuf)
   "Append MSG to dashboard buffer.
@@ -157,7 +157,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
        (goto-char 0)
        (let ((margin (max 0 (floor (/ (- dashboard-banner-length banner-width) 2)))))
          (while (not (eobp))
-	   (insert (make-string margin ?\ ))
+					 (insert (make-string margin ?\ ))
            (forward-line 1))))
      (buffer-string))))
 
@@ -181,9 +181,9 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
       (insert-image spec)
       (insert "\n\n")
       (when title
-	(insert (make-string (max 0 (floor (/ (- dashboard-banner-length
-						 (+ (length title) 1)) 2))) ?\ ))
-	(insert (format "%s\n\n" (propertize title 'face 'dashboard-banner-logo-title-face)))))))
+				(insert (make-string (max 0 (floor (/ (- dashboard-banner-length
+																								 (+ (length title) 1)) 2))) ?\ ))
+				(insert (format "%s\n\n" (propertize title 'face 'dashboard-banner-logo-title-face)))))))
 
 (defun dashboard-get-banner-path (index)
   "Return the full path to banner with index INDEX."
@@ -196,7 +196,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
            (if (and (display-graphic-p) (image-type-available-p 'png))
                dashboard-banner-official-png
              (dashboard-get-banner-path 1)))
-	  ((eq 'logo dashboard-startup-banner)
+					((eq 'logo dashboard-startup-banner)
            (if (and (display-graphic-p) (image-type-available-p 'png))
                dashboard-banner-logo-png
              (dashboard-get-banner-path 1)))
@@ -208,9 +208,9 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                 (display-graphic-p))
            (if (file-exists-p dashboard-startup-banner)
                dashboard-startup-banner
-	     (message (format "could not find banner %s"
-			      dashboard-startup-banner))
-	     (dashboard-get-banner-path 1)))
+						 (message (format "could not find banner %s"
+															dashboard-startup-banner))
+						 (dashboard-get-banner-path 1)))
           (t (dashboard-get-banner-path 1)))))
 
 (defun dashboard-insert-banner ()
@@ -220,7 +220,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
         (buffer-read-only nil))
     (progn
       (when banner
-	(if (image-type-available-p (intern (file-name-extension banner)))
+				(if (image-type-available-p (intern (file-name-extension banner)))
             (dashboard-insert-image-banner banner)
           (dashboard-insert-ascii-banner-centered banner))))))
 
@@ -229,27 +229,35 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 ;;
 (defun dashboard-insert-recentf-list (list-display-name list)
   "Render LIST-DISPLAY-NAME title and items of LIST."
-  (when (car list)
-    (dashboard-insert-heading list-display-name)
-    (mapc (lambda (el)
-            (insert "\n    ")
-            (widget-create 'push-button
-                           :action `(lambda (&rest ignore) (find-file-existing ,el))
-                           :mouse-face 'highlight
-                           :follow-link "\C-m"
-                           :button-prefix ""
-                           :button-suffix ""
-                           :format "%[%t%]"
-                           (abbreviate-file-name el)))
-          list)))
+  (let ((max-line-length 0))
+		(when (car list)
+			(dashboard-insert-heading list-display-name)
+			(mapc (lambda (el)
+							(let ((widget nil))
+								(insert "\n    ")
+								(setq widget
+											(widget-create 'push-button
+																		 :action `(lambda (&rest ignore) (find-file-existing ,el))
+																		 :mouse-face 'highlight
+																		 :follow-link "\C-m"
+																		 :button-prefix ""
+																		 :button-suffix ""
+																		 :format "%[%t%]"
+																		 (abbreviate-file-name el)))
+								(setq max-line-length
+											(max max-line-length (length (widget-value-value-get widget))))))
+						list))
+		max-line-length))
 
 (defun dashboard-insert-recents (list-size)
   "Add the list of LIST-SIZE items from recently edited files."
   (recentf-mode)
-  (when (dashboard-insert-recentf-list
-	 "Recent Files:"
-	 (dashboard-subseq recentf-list 0 list-size))
-    (dashboard-insert-shortcut "r" "Recent Files:")))
+  (when-let ((max-line-length
+							(dashboard-insert-recentf-list
+							 "Recent Files:"
+							 (dashboard-subseq recentf-list 0 list-size))))
+    (dashboard-insert-shortcut "r" "Recent Files:")
+		max-line-length))
 
 
 ;;
@@ -278,9 +286,9 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   "Add the list of LIST-SIZE items of bookmarks."
   (require 'bookmark)
   (when (dashboard-insert-bookmark-list
-	 "Bookmarks:"
-	 (dashboard-subseq (bookmark-all-names)
-			   0 list-size))
+				 "Bookmarks:"
+				 (dashboard-subseq (bookmark-all-names)
+													 0 list-size))
     (dashboard-insert-shortcut "m" "Bookmarks:")))
 
 ;;
@@ -294,7 +302,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
             (insert "\n    ")
             (widget-create 'push-button
                            :action `(lambda (&rest ignore)
-				      (projectile-switch-project-by-name ,el))
+																			(projectile-switch-project-by-name ,el))
                            :mouse-face 'highlight
                            :follow-link "\C-m"
                            :button-prefix ""
@@ -310,12 +318,12 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   (projectile-mode)
   (if (bound-and-true-p projectile-mode)
       (progn
-	(projectile-load-known-projects)
-	(when (dashboard-insert-project-list
-	       "Projects:"
-	       (dashboard-subseq (projectile-relevant-known-projects)
-				 0 list-size))
-	  (dashboard-insert-shortcut "p" "Projects:")))
+				(projectile-load-known-projects)
+				(when (dashboard-insert-project-list
+							 "Projects:"
+							 (dashboard-subseq (projectile-relevant-known-projects)
+																 0 list-size))
+					(dashboard-insert-shortcut "p" "Projects:")))
     (message "Failed to load projects list")))
 
 ;;
@@ -384,16 +392,16 @@ date part is considered."
     (org-map-entries
      (lambda ()
        (let* ((schedule-time (org-get-scheduled-time (point)))
-             (deadline-time (org-get-deadline-time (point)))
-             (item (org-agenda-format-item
-		    (format-time-string "%Y-%m-%d" schedule-time)
-                    (org-get-heading t t)
-                    (org-outline-level)
-                    (org-get-category)
-                    (org-get-tags)
-                    t))
-             (loc (point))
-             (file (buffer-file-name)))
+							(deadline-time (org-get-deadline-time (point)))
+							(item (org-agenda-format-item
+										 (format-time-string "%Y-%m-%d" schedule-time)
+                     (org-get-heading t t)
+                     (org-outline-level)
+                     (org-get-category)
+                     (org-get-tags)
+                     t))
+							(loc (point))
+							(file (buffer-file-name)))
          (when (and (not (org-entry-is-done-p))
                     (or (and schedule-time (dashboard-date-due-p schedule-time due-date))
                         (and deadline-time (dashboard-date-due-p deadline-time due-date))))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -239,7 +239,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 ;; Section insertion
 ;;
 (defmacro dashboard-insert-section-list (section-name list action &rest rest)
-  "Insert a LIST of items with SECTION-NAME, expanding ACTION and passing REST to widget creation."
+  "Insert into SECTION-NAME a LIST of items, expanding ACTION and passing REST to widget creation."
   `(let ((max-line-length 0))
      (when (car ,list)
        (mapc (lambda (el)
@@ -261,10 +261,9 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 
 (defmacro dashboard-insert-section (section-name list list-size shortcut action &rest widget-params)
   "Add a section with SECTION-NAME and LIST of LIST-SIZE items to the dashboard.
-ACTION is theaction taken when the user activates the widget button.
 SHORTCUT is the keyboard shortcut used to access the section.
-WIDGET-PARAMS are passed to the \"widget-create\" function.
-Show EMPTY-LIST-TEXT if no items in list"
+ACTION is theaction taken when the user activates the widget button.
+WIDGET-PARAMS are passed to the \"widget-create\" function."
   `(progn
      (dashboard-insert-heading ,section-name)
      (let ((max-line-length (dashboard-insert-section-list

--- a/dashboard.el
+++ b/dashboard.el
@@ -125,7 +125,7 @@
       (setq dashboard-banner-length (window-width)
             dashboard-buffer-last-width dashboard-banner-length)
       (with-current-buffer (get-buffer-create dashboard-buffer-name)
-	(let ((buffer-read-only nil)
+        (let ((buffer-read-only nil)
               (list-separator "\n\n"))
           (erase-buffer)
           (dashboard-insert-banner)
@@ -133,28 +133,27 @@
           (setq dashboard--section-starts nil)
           (mapc (lambda (els)
                   (let* ((el (or (car-safe els) els))
-												 (list-size
+                         (list-size
                           (or (cdr-safe els)
                               dashboard-items-default-length))
-												 (item-generator
+                         (item-generator
                           (cdr-safe (assoc el dashboard-item-generators))))
                     (add-to-list 'dashboard--section-starts (point))
                     (setq max-line-length
-													(max max-line-length (or (funcall item-generator list-size) 0)))
+                          (max max-line-length (or (funcall item-generator list-size) 0)))
                     (dashboard-insert-page-break)))
-								dashboard-items)
-					(if dashboard-center-content
-							(progn
-								(goto-char (car (last dashboard--section-starts)))
-								(let ((margin (floor (/ (- (window-width) max-line-length)  2))))
-									(while (not (eobp))
-										(and (not (eq ? (char-after)))
-												 (insert (make-string margin ?\ )))
-										(forward-line 1))))))
-				(dashboard-mode)
-				(goto-char (point-min))))
+                dashboard-items)
+          (when dashboard-center-content
+            (goto-char (car (last dashboard--section-starts)))
+            (let ((margin (floor (/ (- (window-width) max-line-length)  2))))
+              (while (not (eobp))
+                (and (not (eq ? (char-after)))
+                     (insert (make-string margin ?\ )))
+                (forward-line 1)))))
+        (dashboard-mode)
+        (goto-char (point-min))))
     (if recentf-is-on
-				(setq recentf-list origial-recentf-list))))
+        (setq recentf-list origial-recentf-list))))
 
 (add-hook 'window-setup-hook
           (lambda ()

--- a/dashboard.el
+++ b/dashboard.el
@@ -134,14 +134,14 @@
                           (cdr-safe (assoc el dashboard-item-generators))))
                     (add-to-list 'dashboard--section-starts (point))
                     (setq max-line-length
-													(max (funcall item-generator list-size)))
+													(max max-line-length (funcall item-generator list-size)))
                     (dashboard-insert-page-break)))
 								dashboard-items)
 					(if dashboard-center-content
 							(progn
-								(goto-char (car dashboard--section-starts))
-								(dashboard-next-section)
-								(let ((margin (max 0 (floor (/ (- (window-width) max-line-length)  2)))))
+								(goto-char (car (last dashboard--section-starts)))
+								(let ((margin (floor (/ (- (window-width) max-line-length)  2))))
+									(message "%d %d %d" (window-width) max-line-length margin)
 									(while (not (eobp))
 										(insert (make-string margin ?\ ))
 										(forward-line 1))))))

--- a/dashboard.el
+++ b/dashboard.el
@@ -62,7 +62,7 @@
   "Settings that are used in the Dashboard"
   :group 'dashboard)
 
-(defcustom dashboard-center-content t
+(defcustom dashboard-center-content nil
   "Whether to center content within the window."
   :type 'boolean
   :group 'dashboard)

--- a/dashboard.el
+++ b/dashboard.el
@@ -105,11 +105,11 @@
   "Insert the list of widgets into the buffer."
   (interactive)
   (let ((buffer-exists (buffer-live-p (get-buffer dashboard-buffer-name)))
-	(save-line nil)
-	(recentf-is-on (recentf-enabled-p))
-	(origial-recentf-list recentf-list)
-	(dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0))
-	)
+				(save-line nil)
+				(recentf-is-on (recentf-enabled-p))
+				(origial-recentf-list recentf-list)
+				(dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0))
+				(max-line-length 0))
     ;; disable recentf mode,
     ;; so we don't flood the recent files list with org mode files
     ;; do this by making a copy of the part of the list we'll use

--- a/dashboard.el
+++ b/dashboard.el
@@ -105,11 +105,11 @@
   "Insert the list of widgets into the buffer."
   (interactive)
   (let ((buffer-exists (buffer-live-p (get-buffer dashboard-buffer-name)))
-				(save-line nil)
-				(recentf-is-on (recentf-enabled-p))
-				(origial-recentf-list recentf-list)
-				(dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0))
-				(max-line-length 0))
+	(save-line nil)
+	(recentf-is-on (recentf-enabled-p))
+	(origial-recentf-list recentf-list)
+	(dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0))
+	)
     ;; disable recentf mode,
     ;; so we don't flood the recent files list with org mode files
     ;; do this by making a copy of the part of the list we'll use
@@ -118,13 +118,14 @@
     ;; (this avoids many saves/loads that would result from
     ;; disabling/enabling recentf-mode)
     (if recentf-is-on
-				(setq recentf-list (seq-take recentf-list dashboard-num-recents)))
+	(setq recentf-list (seq-take recentf-list dashboard-num-recents))
+      )
     (when (or (not (eq dashboard-buffer-last-width (window-width)))
               (not buffer-exists))
       (setq dashboard-banner-length (window-width)
             dashboard-buffer-last-width dashboard-banner-length)
       (with-current-buffer (get-buffer-create dashboard-buffer-name)
-				(let ((buffer-read-only nil)
+	(let ((buffer-read-only nil)
               (list-separator "\n\n"))
           (erase-buffer)
           (dashboard-insert-banner)

--- a/dashboard.el
+++ b/dashboard.el
@@ -63,9 +63,9 @@
   :group 'dashboard)
 
 (defcustom dashboard-center-content t
-	"Whether to center content within the window."
-	:type 'boolean
-	:group 'dashboard)
+  "Whether to center content within the window."
+  :type 'boolean
+  :group 'dashboard)
 
 (defconst dashboard-buffer-name "*dashboard*"
   "Dashboard's buffer name.")
@@ -107,11 +107,11 @@
   "Insert the list of widgets into the buffer."
   (interactive)
   (let ((buffer-exists (buffer-live-p (get-buffer dashboard-buffer-name)))
-				(save-line nil)
-				(recentf-is-on (recentf-enabled-p))
-				(origial-recentf-list recentf-list)
-				(dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0))
-				(max-line-length 0))
+        (save-line nil)
+        (recentf-is-on (recentf-enabled-p))
+        (origial-recentf-list recentf-list)
+        (dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0))
+        (max-line-length 0))
     ;; disable recentf mode,
     ;; so we don't flood the recent files list with org mode files
     ;; do this by making a copy of the part of the list we'll use

--- a/dashboard.el
+++ b/dashboard.el
@@ -62,6 +62,11 @@
   "Settings that are used in the Dashboard"
   :group 'dashboard)
 
+(defcustom dashboard-center-content t
+	"Whether to center content within the window."
+	:type 'boolean
+	:group 'dashboard)
+
 (defconst dashboard-buffer-name "*dashboard*"
 	  "Dashboard's buffer name.")
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -103,6 +103,18 @@
      (when next-section-start
        (goto-char next-section-start)))))
 
+(defun dashboard-maximum-section-length ()
+  "For the just-inserted section, calculate the length of the longest line."
+  (let ((max-line-length 0))
+    (save-excursion
+      (dashboard-previous-section)
+      (while (not (eobp))
+        (setq max-line-length
+              (max max-line-length
+                   (- (line-end-position) (line-beginning-position))))
+        (forward-line)))
+    max-line-length))
+
 (defun dashboard-insert-startupify-lists ()
   "Insert the list of widgets into the buffer."
   (interactive)
@@ -141,8 +153,9 @@
                          (item-generator
                           (cdr-safe (assoc el dashboard-item-generators))))
                     (add-to-list 'dashboard--section-starts (point))
+                    (funcall item-generator list-size)
                     (setq max-line-length
-                          (max max-line-length (or (funcall item-generator list-size) 0)))
+                          (max max-line-length (dashboard-maximum-section-length)))
                     (dashboard-insert-page-break)))
                 dashboard-items)
           (when dashboard-center-content

--- a/dashboard.el
+++ b/dashboard.el
@@ -147,7 +147,8 @@
 								(goto-char (car (last dashboard--section-starts)))
 								(let ((margin (floor (/ (- (window-width) max-line-length)  2))))
 									(while (not (eobp))
-										(insert (make-string margin ?\ ))
+										(and (not (eq ? (char-after)))
+												 (insert (make-string margin ?\ )))
 										(forward-line 1))))))
 				(dashboard-mode)
 				(goto-char (point-min))))

--- a/dashboard.el
+++ b/dashboard.el
@@ -139,14 +139,13 @@
                           (cdr-safe (assoc el dashboard-item-generators))))
                     (add-to-list 'dashboard--section-starts (point))
                     (setq max-line-length
-													(max max-line-length (funcall item-generator list-size)))
+													(max max-line-length (or (funcall item-generator list-size) 0)))
                     (dashboard-insert-page-break)))
 								dashboard-items)
 					(if dashboard-center-content
 							(progn
 								(goto-char (car (last dashboard--section-starts)))
 								(let ((margin (floor (/ (- (window-width) max-line-length)  2))))
-									(message "%d %d %d" (window-width) max-line-length margin)
 									(while (not (eobp))
 										(insert (make-string margin ?\ ))
 										(forward-line 1))))))


### PR DESCRIPTION
Hello @rakanalh. This PR addresses https://github.com/emacs-dashboard/emacs-dashboard/issues/77  
I approached this by creating a macro that can insert arbtrary sections and returns the maximum line length for that section. Then `'dashboard-insert-startupify-lists` finds the maximum of the maximums and moves all items over accordingly. I initially looked at adjusting the margins and/or the gutter but neither looked very attractive.

Additionally, I'd be willing to be a maintainer. I've been looking for something fun to hack on for a while. Thanks for considering.