### PR TITLE
fixes #87 - Unwanted `RET` typed into buffer when clicked

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -247,7 +247,6 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
             (widget-create 'push-button
                            :action `(lambda (&rest ignore) (find-file-existing ,el))
                            :mouse-face 'highlight
-                           :follow-link "\C-m"
                            :button-prefix ""
                            :button-suffix ""
                            :format "%[%t%]"
@@ -275,7 +274,6 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
             (widget-create 'push-button
                            :action `(lambda (&rest ignore) (bookmark-jump ,el))
                            :mouse-face 'highlight
-                           :follow-link "\C-m"
                            :button-prefix ""
                            :button-suffix ""
                            :format "%[%t%]"
@@ -307,7 +305,6 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                            :action `(lambda (&rest ignore)
                                       (projectile-switch-project-by-name ,el))
                            :mouse-face 'highlight
-                           :follow-link "\C-m"
                            :button-prefix ""
                            :button-suffix ""
                            :format "%[%t%]"
@@ -349,7 +346,6 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                                               )
                                             (switch-to-buffer buffer)))
                                :mouse-face 'highlight
-                               :follow-link "\C-m"
                                :button-prefix ""
                                :button-suffix ""
                                :format "%[%t%]"
@@ -440,7 +436,6 @@ date part is considered."
               (widget-create 'push-button
                              :action `(lambda (&rest ignore) (jump-to-register ,register))
                              :mouse-face 'highlight
-                             :follow-link "\C-m"
                              :button-prefix ""
                              :button-suffix ""
                              :format "%[%t%]"


### PR DESCRIPTION
fixes #87 
by removing `:follow-link "C-m"` arguments from all the widget creation calls