### PR TITLE
Improve project badges

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,8 @@
-* Emacs Dashboard
+* Emacs Dashboard [[https://melpa.org/#/dashboard][https://melpa.org/packages/dashboard-badge.svg]]
 
 [[https://circleci.com/gh/emacs-dashboard/emacs-dashboard/tree/master.svg?style=svg]]
+
+
 
 An extensible emacs startup screen showing you what's most important.
 

--- a/README.org
+++ b/README.org
@@ -1,8 +1,6 @@
-* Emacs Dashboard [[https://melpa.org/#/dashboard][https://melpa.org/packages/dashboard-badge.svg]]
+* Emacs Dashboard [[https://melpa.org/#/dashboard][https://melpa.org/packages/dashboard-badge.svg]] [[https://stable.melpa.org/#/dashboard][https://stable.melpa.org/packages/dashboard-badge.svg]]
 
 [[https://circleci.com/gh/emacs-dashboard/emacs-dashboard/tree/master.svg?style=svg]]
-
-
 
 An extensible emacs startup screen showing you what's most important.
 

--- a/README.org
+++ b/README.org
@@ -1,6 +1,4 @@
-* Emacs Dashboard [[https://melpa.org/#/dashboard][https://melpa.org/packages/dashboard-badge.svg]] [[https://stable.melpa.org/#/dashboard][https://stable.melpa.org/packages/dashboard-badge.svg]]
-
-[[https://circleci.com/gh/emacs-dashboard/emacs-dashboard/tree/master.svg?style=svg]]
+* Emacs Dashboard [[https://melpa.org/#/dashboard][https://melpa.org/packages/dashboard-badge.svg]] [[https://stable.melpa.org/#/dashboard][https://stable.melpa.org/packages/dashboard-badge.svg]] [[https://circleci.com/gh/emacs-dashboard][https://img.shields.io/circleci/project/emacs-dashboard/emacs-dashboard.svg]]
 
 An extensible emacs startup screen showing you what's most important.
 


### PR DESCRIPTION
- [x] Add **melpa** badge
- [x] Add **melpa-stable** badge
- [x] Replace CircleCI badge with shields.io version to homogenize

Also, all badges point to the proper link to melpa/melpa-stable/CircleCI

The result can be previewed [here](https://github.com/emacs-dashboard/emacs-dashboard/blob/feature/melpa-badges/README.org)