### PR TITLE
Handle the case where dashboard lines longer than win width

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -160,7 +160,7 @@
                 dashboard-items)
           (when dashboard-center-content
             (goto-char (car (last dashboard--section-starts)))
-            (let ((margin (floor (/ (- (window-width) max-line-length)  2))))
+            (let ((margin (floor (/ (max (- (window-width) max-line-length) 0)  2))))
               (while (not (eobp))
                 (and (not (eq ? (char-after)))
                      (insert (make-string margin ?\ )))


### PR DESCRIPTION
Centering algorithm wasn't considering the fact that the longest line in the dashboard could be longer than the window width. Which isn't normally a problem. But it was trying to insert a negative amount of spaces LOL.

This fixes https://github.com/emacs-dashboard/emacs-dashboard/issues/98