### PR TITLE
Add shortcut indicators to sections

### DIFF
--- a/README.org
+++ b/README.org
@@ -66,6 +66,9 @@ To update the banner or banner title
 
 ;; Content is not centered by default. To center, set
 (setq dashboard-center-content t)
+
+;; To show shortcut "jump" indicators for each section, set
+(setq dashboard-show-shortcuts t)
 #+END_SRC
 
 To customize which widgets are displayed, you can use the following snippet

--- a/README.org
+++ b/README.org
@@ -67,8 +67,8 @@ To update the banner or banner title
 ;; Content is not centered by default. To center, set
 (setq dashboard-center-content t)
 
-;; To show shortcut "jump" indicators for each section, set
-(setq dashboard-show-shortcuts t)
+;; To disable shortcut "jump" indicators for each section, set
+(setq dashboard-show-shortcuts nil)
 #+END_SRC
 
 To customize which widgets are displayed, you can use the following snippet

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -273,6 +273,7 @@ SHORTCUT is the keyboard shortcut used to access the section.
 ACTION is theaction taken when the user activates the widget button.
 WIDGET-PARAMS are passed to the \"widget-create\" function."
   `(progn
+     (eval-when-compile (defvar dashboard-show-shortcuts))
      (dashboard-insert-heading ,section-name (if dashboard-show-shortcuts ,shortcut))
      (when (dashboard-insert-section-list
             ,section-name

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -44,7 +44,7 @@ to the specified width, with aspect ratio preserved."
   :type 'integer
   :group 'dashboard)
 
-(defcustom dashboard-show-shortcuts nil
+(defcustom dashboard-show-shortcuts t
   "Whether to show shortcut keys for each section."
   :type 'boolean
   :group 'dashboard)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -44,6 +44,11 @@ to the specified width, with aspect ratio preserved."
   :type 'integer
   :group 'dashboard)
 
+(defcustom dashboard-show-shortcuts nil
+  "Whether to show shortcut keys for each section."
+  :type 'boolean
+  :group 'dashboard)
+
 (defconst dashboard-banners-directory
   (concat (file-name-directory
            (locate-library "dashboard"))
@@ -273,7 +278,6 @@ SHORTCUT is the keyboard shortcut used to access the section.
 ACTION is theaction taken when the user activates the widget button.
 WIDGET-PARAMS are passed to the \"widget-create\" function."
   `(progn
-     (eval-when-compile (defvar dashboard-show-shortcuts))
      (dashboard-insert-heading ,section-name (if dashboard-show-shortcuts ,shortcut))
      (when (dashboard-insert-section-list
             ,section-name

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -278,7 +278,8 @@ SHORTCUT is the keyboard shortcut used to access the section.
 ACTION is theaction taken when the user activates the widget button.
 WIDGET-PARAMS are passed to the \"widget-create\" function."
   `(progn
-     (dashboard-insert-heading ,section-name (if dashboard-show-shortcuts ,shortcut))
+     (dashboard-insert-heading ,section-name
+                               (if (and ,list dashboard-show-shortcuts) ,shortcut))
      (when (dashboard-insert-section-list
             ,section-name
             (dashboard-subseq ,list 0 list-size)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -155,9 +155,10 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   "Insert a page break line in dashboard buffer."
   (dashboard-append dashboard-page-separator))
 
-(defun dashboard-insert-heading (heading)
-  "Insert a widget HEADING in dashboard buffer."
-  (insert (propertize heading 'face 'dashboard-heading-face)))
+(defun dashboard-insert-heading (heading &optional shortcut)
+  "Insert a widget HEADING in dashboard buffer, adding SHORTCUT if provided."
+  (insert (propertize heading 'face 'dashboard-heading-face))
+  (if shortcut (insert (format " (%s)" shortcut))))
 
 ;;
 ;; BANNER
@@ -272,7 +273,7 @@ SHORTCUT is the keyboard shortcut used to access the section.
 ACTION is theaction taken when the user activates the widget button.
 WIDGET-PARAMS are passed to the \"widget-create\" function."
   `(progn
-     (dashboard-insert-heading ,section-name)
+     (dashboard-insert-heading ,section-name (if dashboard-show-shortcuts ,shortcut))
      (when (dashboard-insert-section-list
             ,section-name
             (dashboard-subseq ,list 0 list-size)

--- a/dashboard.el
+++ b/dashboard.el
@@ -67,11 +67,6 @@
   :type 'boolean
   :group 'dashboard)
 
-(defcustom dashboard-show-shortcuts nil
-  "Whether to show shortcut keys for each section."
-  :type 'boolean
-  :group 'dashboard)
-
 (defconst dashboard-buffer-name "*dashboard*"
   "Dashboard's buffer name.")
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -67,6 +67,11 @@
   :type 'boolean
   :group 'dashboard)
 
+(defcustom dashboard-show-shortcuts nil
+  "Whether to show shortcut keys for each section."
+  :type 'boolean
+  :group 'dashboard)
+
 (defconst dashboard-buffer-name "*dashboard*"
   "Dashboard's buffer name.")
 


### PR DESCRIPTION
A small enhancement. Show shortcut indicators (if specified) for each section. Open to suggestions. Useful? Add font-lock?

![image](https://user-images.githubusercontent.com/623494/53568797-dcc6dd00-3b30-11e9-881f-4a1d25d3699b.png)
