### PR TITLE
Generate symbol in let. make-symbol failing occasionally in body

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -131,8 +131,7 @@ Return entire list if `END' is omitted."
 Optionally, provide NO-NEXT-LINE to move the cursor forward a line."
   `(progn
      (eval-when-compile (defvar dashboard-mode-map))
-     (let ((tempsym (make-symbol (format "Jump to \"%s\"" ,search-label))))
-       (set 'sym tempsym)
+     (let ((sym (make-symbol (format "Jump to \"%s\"" ,search-label))))
        (fset sym (lambda ()
                    (interactive)
                    (unless (search-forward ,search-label (point-max) t)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -131,8 +131,8 @@ Return entire list if `END' is omitted."
 Optionally, provide NO-NEXT-LINE to move the cursor forward a line."
   `(progn
      (eval-when-compile (defvar dashboard-mode-map))
-     (let ((sym nil))
-       (set 'sym (make-symbol (format "Jump to \"%s\"" ,search-label)))
+     (let ((tempsym (make-symbol (format "Jump to \"%s\"" ,search-label))))
+       (set 'sym tempsym)
        (fset sym (lambda ()
                    (interactive)
                    (unless (search-forward ,search-label (point-max) t)


### PR DESCRIPTION
A small fix. I added `dashboard-hackernews` to my dashboard, updated it to call the new `dashboard-insert-section` and it was having trouble generating the symbol for the lambda that is the keyboard jump. Probably because it makes some async calls prior. This seems to solve this issue.