### PR TITLE
Fix error in `dashboard-next-section`

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -93,14 +93,14 @@
   "Navigate forward to next section."
   (interactive)
   (let ((current-position (point))
-         (next-section-start nil)
-         (section-starts (reverse dashboard--section-starts)))
-     (dolist (elt section-starts)
-       (when (and (not next-section-start)
-                  (> elt current-position))
-         (setq next-section-start elt)))
-     (when next-section-start
-       (goto-char next-section-start))))
+        (next-section-start nil)
+        (section-starts (reverse dashboard--section-starts)))
+    (dolist (elt section-starts)
+      (when (and (not next-section-start)
+                 (> elt current-position))
+        (setq next-section-start elt)))
+    (when next-section-start
+      (goto-char next-section-start))))
 
 (defun dashboard-maximum-section-length ()
   "For the just-inserted section, calculate the length of the longest line."

--- a/dashboard.el
+++ b/dashboard.el
@@ -91,8 +91,8 @@
 
 (defun dashboard-next-section ()
   "Navigate forward to next section."
-  (interactive
-   (let ((current-position (point))
+  (interactive)
+  (let ((current-position (point))
          (next-section-start nil)
          (section-starts (reverse dashboard--section-starts)))
      (dolist (elt section-starts)
@@ -100,7 +100,7 @@
                   (> elt current-position))
          (setq next-section-start elt)))
      (when next-section-start
-       (goto-char next-section-start)))))
+       (goto-char next-section-start))))
 
 (defun dashboard-maximum-section-length ()
   "For the just-inserted section, calculate the length of the longest line."


### PR DESCRIPTION
The function body for `dashboard-next-section` is contained in the body of the starting `(interactive)` form, whereas it shouldn't be :)

The command still "works" since we try to evaluate the body of `interactive`, but pressing `}` signals an error every time.
