### PR TITLE
Add action to widget-create

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -325,7 +325,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
 ;;
 ;; Section list
 ;;
-(defmacro dashboard-insert-section-list (section-name list _action &rest rest)
+(defmacro dashboard-insert-section-list (section-name list action &rest rest)
   "Insert into SECTION-NAME a LIST of items, expanding ACTION and passing REST to widget creation."
   `(when (car ,list)
      (mapc
@@ -362,6 +362,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
               (setq tag (concat icon " " ,@rest))))
 
           (widget-create 'file-link
+                         :action ,action
                          :tag tag
                          :mouse-face 'highlight
                          :help-echo el

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -509,7 +509,7 @@ date part is considered."
    register-alist
    list-size
    "e"
-   (lambda (&rest ignore) (jump-to-register (car el)))
+   `(lambda (&rest ignore) (jump-to-register (car el)))
    (format "%c - %s" (car el) (register-describe-oneline (car el)))))
 
 


### PR DESCRIPTION
Action wasn't being assigned when the widget was created.

Fix #133 

Please, :+1: if it seems good @seagle0128 @ema2159 