### PR TITLE
Circumvented use of `package-activated-list` if package.el is not used

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -88,7 +88,7 @@ to the specified width, with aspect ratio preserved."
   ;; Check if package.el was loaded and if package loading was enabled
   (if (bound-and-true-p package-enable-at-startup)
       (format "%d packages loaded in %s"
-            (length package-activated-list) (emacs-init-time))
+              (length package-activated-list) (emacs-init-time))
     (format "Emacs started in %s" (emacs-init-time)))
   "Init info with packages loaded and init time.")
 

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -84,8 +84,12 @@ to the specified width, with aspect ratio preserved."
 (defvar dashboard-banner-logo-title "Welcome to Emacs!"
   "Specify the startup banner.")
 
-(defvar dashboard-init-info (format "%d packages loaded in %s"
-                                    (length package-activated-list) (emacs-init-time))
+(defvar dashboard-init-info
+  ;; Check if package.el was loaded and if package loading was enabled
+  (if (bound-and-true-p package-enable-at-startup)
+      (format "%d packages loaded in %s"
+            (length package-activated-list) (emacs-init-time))
+    (format "Emacs started in %s" (emacs-init-time)))
   "Init info with packages loaded and init time.")
 
 (defvar dashboard-startup-banner 'official


### PR DESCRIPTION
This should fix #136.

I tried to look around to see if there was a very reliable way to determine if package.el is being used. Unfortunately, I didn't really find a foolproof method. This PR is my best attempt at providing something that is somewhat reliable, and it at least solves my issue.

My Emacs and Elisp skills are basically terrible, so feel free to reject this if it's not up to snuff.