### PR TITLE
Add the navigator below the banner with the customized buttons.

### DIFF
--- a/README.org
+++ b/README.org
@@ -102,6 +102,23 @@ To modify heading icons with another icon from all-the-icons octicons:
                                   (bookmarks . "book")))
 #+END_SRC
 
+To show navigator below the banner:
+#+BEGIN_SRC emacs-lisp
+(setq dashboard-set-navigator t)
+#+END_SRC
+
+To customize the buttons of the navigator like this:
+#+BEGIN_SRC emacs-lisp
+;; Format: "icon title help action face"
+(setq dashboard-navigator-buttons
+      `((,(all-the-icons-octicon "mark-github" :height 1.1 :v-adjust 0.0)
+         "Homepage"
+         "Browse homepage"
+         (lambda (&rest _) (browse-url "homepage")))
+        ("★" "Star" "Show stars" (lambda (&rest _) (show-stars)) 'warning)
+        ("?" "Help" "?/h" #'show-help nil)))
+#+END_SRC
+
 To show info about the packages loaded and the init time:
 #+BEGIN_SRC elisp
 (setq dashboard-set-init-info t)

--- a/README.org
+++ b/README.org
@@ -109,14 +109,14 @@ To show navigator below the banner:
 
 To customize the buttons of the navigator like this:
 #+BEGIN_SRC emacs-lisp
-;; Format: "icon title help action face"
+;; Format: "icon title help action face prefix suffix"
 (setq dashboard-navigator-buttons
       `((,(all-the-icons-octicon "mark-github" :height 1.1 :v-adjust 0.0)
          "Homepage"
          "Browse homepage"
          (lambda (&rest _) (browse-url "homepage")))
         ("★" "Star" "Show stars" (lambda (&rest _) (show-stars)) 'warning)
-        ("?" "Help" "?/h" #'show-help nil)))
+        ("?" "Help" "?/h" #'show-help nil "<" ">")))
 #+END_SRC
 
 To show info about the packages loaded and the init time:

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -388,7 +388,6 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 (defun dashboard-insert-navigator ()
   "Insert Navigator of the dashboard."
   (when (and dashboard-set-navigator dashboard-navigator-buttons)
-    (insert "\n")
     (dolist (btn dashboard-navigator-buttons)
       (let* ((icon (car btn))
              (title (or (cadr btn) ""))
@@ -418,7 +417,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
       (beginning-of-line)
       (dashboard-center-line (make-string width ?\s))
       (end-of-line))
-    (insert "\n\n\n")))
+    (insert "\n\n")))
 
 (defmacro dashboard-insert-section (section-name list list-size shortcut action &rest widget-params)
   "Add a section with SECTION-NAME and LIST of LIST-SIZE items to the dashboard.

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -95,10 +95,10 @@ to the specified width, with aspect ratio preserved."
 
 (defvar dashboard-navigator-buttons nil
   "Specify the navigator buttons.
-The format is: 'icon title help action face'.
+The format is: 'icon title help action face prefix suffix'.
 
 Example:
-'((\"☆\" \"Star\" \"Show stars\" (lambda (&rest _) (show-stars)) 'warning))")
+'((\"☆\" \"Star\" \"Show stars\" (lambda (&rest _) (show-stars)) 'warning \"[\" \"]\"))")
 
 (defvar dashboard-init-info
   ;; Check if package.el was loaded and if package loading was enabled
@@ -390,11 +390,13 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   (when (and dashboard-set-navigator dashboard-navigator-buttons)
     (insert "\n")
     (dolist (btn dashboard-navigator-buttons)
-      (let ((icon (car btn))
-            (title (or (cadr btn) ""))
-            (help (or (cadr (cdr btn)) ""))
-            (action (cadr (cddr btn)))
-            (face (or (cddr (cddr btn)) 'dashboard-navigator)))
+      (let* ((icon (car btn))
+             (title (or (cadr btn) ""))
+             (help (or (cadr (cdr btn)) ""))
+             (action (or (cadr (cddr btn)) #'ignore))
+             (face (or (cadr (cddr (cdr btn))) 'dashboard-navigator))
+             (prefix (or (cadr (cddr (cddr btn))) (propertize "[" 'face face)))
+             (suffix (or (cadr (cddr (cddr (cdr btn)))) (propertize "]" 'face face))))
         (widget-create 'item
                        :tag (concat
                              (when icon
@@ -408,8 +410,8 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                        :help-echo help
                        :action action
                        :mouse-face 'highlight
-                       :button-prefix (propertize "[" 'face face)
-                       :button-suffix (propertize "]" 'face face)
+                       :button-prefix prefix
+                       :button-suffix suffix
                        :format "%[%t%]")
         (insert " ")))
     (let* ((width (current-column)))


### PR DESCRIPTION
@JesusMtnez @ema2159 , I port the navigator feature from my `Centaur Emacs`. Please review and merge. Thanks!

To show navigator below the banner:
```elisp
(setq dashboard-set-navigator t)
```

To customize the buttons of the navigator like this:
```elisp
;; Format: "icon title help action face"
(setq dashboard-navigator-buttons
      `((,(all-the-icons-octicon "mark-github" :height 1.1 :v-adjust 0.0)
         "Homepage"
         "Browse homepage"
         (lambda (&rest _) (browse-url "homepage")))
        ("★" "Star" "Show stars" (lambda (&rest _) (show-stars)) 'warning)
        ("?" "Help" "?/h" #'show-help nil)))
```