### PR TITLE
Support `straight.el` properly in `dashboard-init-info`

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -93,7 +93,10 @@ to the specified width, with aspect ratio preserved."
   (if (bound-and-true-p package-alist)
       (format "%d packages loaded in %s"
               (length package-activated-list) (emacs-init-time))
-    (format "Emacs started in %s" (emacs-init-time)))
+    (if (and (boundp 'straight--profile-cache) (hash-table-p straight--profile-cache))
+        (format "%d packages loaded in %s"
+                (hash-table-size straight--profile-cache) (emacs-init-time))
+      (format "Emacs started in %s" (emacs-init-time))))
   "Init info with packages loaded and init time.")
 
 (defvar dashboard-footer

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -90,7 +90,7 @@ to the specified width, with aspect ratio preserved."
 
 (defvar dashboard-init-info
   ;; Check if package.el was loaded and if package loading was enabled
-  (if (featurep 'package)
+  (if (bound-and-true-p package-alist)
       (format "%d packages loaded in %s"
               (length package-activated-list) (emacs-init-time))
     (format "Emacs started in %s" (emacs-init-time)))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -90,7 +90,7 @@ to the specified width, with aspect ratio preserved."
 
 (defvar dashboard-init-info
   ;; Check if package.el was loaded and if package loading was enabled
-  (if (bound-and-true-p package-enable-at-startup)
+  (if (featurep 'package)
       (format "%d packages loaded in %s"
               (length package-activated-list) (emacs-init-time))
     (format "Emacs started in %s" (emacs-init-time)))


### PR DESCRIPTION
- Use `(bound-and-true-p package-alist)` to check if `package.el` is enabled.
- Use ` (and (boundp 'straight--profile-cache) (hash-table-p straight--profile-cache))` to check if `straight.el` is enabled.

This should fix discussion in https://github.com/emacs-dashboard/emacs-dashboard/pull/138

@romatthe could you please check if this works for you with `straight.el`?
@ema2159 I would also like your opinion on this