### PR TITLE
Support multiple lines for the navigator.

### DIFF
--- a/README.org
+++ b/README.org
@@ -109,14 +109,21 @@ To show navigator below the banner:
 
 To customize the buttons of the navigator like this:
 #+BEGIN_SRC emacs-lisp
-;; Format: "icon title help action face prefix suffix"
+;; Format: "(icon title help action face prefix suffix)"
 (setq dashboard-navigator-buttons
-      `((,(all-the-icons-octicon "mark-github" :height 1.1 :v-adjust 0.0)
+      `(;; line1
+        ((,(all-the-icons-octicon "mark-github" :height 1.1 :v-adjust 0.0)
          "Homepage"
          "Browse homepage"
          (lambda (&rest _) (browse-url "homepage")))
-        ("★" "Star" "Show stars" (lambda (&rest _) (show-stars)) 'warning)
-        ("?" "Help" "?/h" #'show-help nil "<" ">")))
+        ("★" "Star" "Show stars" (lambda (&rest _) (show-stars)) warning)
+        ("?" "" "?/h" #'show-help nil "<" ">"))
+         ;; line 2
+        ((,(all-the-icons-faicon "linkedin" :height 1.1 :v-adjust 0.0)
+          "Linkedin"
+          ""
+          (lambda (&rest _) (browse-url "homepage")))
+         ("⚑" nil "Show flags" (lambda (&rest _) (message "flag")) error))))
 #+END_SRC
 
 To show info about the packages loaded and the init time:

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -393,36 +393,40 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 (defun dashboard-insert-navigator ()
   "Insert Navigator of the dashboard."
   (when (and dashboard-set-navigator dashboard-navigator-buttons)
-    (dolist (btn dashboard-navigator-buttons)
-      (let* ((icon (car btn))
-             (title (or (cadr btn) ""))
-             (help (or (cadr (cdr btn)) ""))
-             (action (or (cadr (cddr btn)) #'ignore))
-             (face (or (cadr (cddr (cdr btn))) 'dashboard-navigator))
-             (prefix (or (cadr (cddr (cddr btn))) (propertize "[" 'face face)))
-             (suffix (or (cadr (cddr (cddr (cdr btn)))) (propertize "]" 'face face))))
-        (widget-create 'item
-                       :tag (concat
-                             (when icon
-                               (concat
-                                (propertize icon 'face `(:inherit
-                                                         ,(get-text-property 0 'face icon)
-                                                         :inherit
-                                                         ,face))
-                                (propertize " " 'face 'variable-pitch)))
-                             (propertize title 'face face))
-                       :help-echo help
-                       :action action
-                       :mouse-face 'highlight
-                       :button-prefix prefix
-                       :button-suffix suffix
-                       :format "%[%t%]")
-        (insert " ")))
-    (let* ((width (current-column)))
-      (beginning-of-line)
-      (dashboard-center-line (make-string width ?\s))
-      (end-of-line))
-    (insert "\n\n")))
+    (dolist (line dashboard-navigator-buttons)
+      (dolist (btn line)
+        (let* ((icon (car btn))
+               (title (cadr btn))
+               (help (or (cadr (cdr btn)) ""))
+               (action (or (cadr (cddr btn)) #'ignore))
+               (face (or (cadr (cddr (cdr btn))) 'dashboard-navigator))
+               (prefix (or (cadr (cddr (cddr btn))) (propertize "[" 'face face)))
+               (suffix (or (cadr (cddr (cddr (cdr btn)))) (propertize "]" 'face face))))
+          (widget-create 'item
+                         :tag (concat
+                               (when icon
+                                 (propertize icon 'face `(:inherit
+                                                          ,(get-text-property 0 'face icon)
+                                                          :inherit
+                                                          ,face)))
+                               (when (and icon title
+                                          (not (string-equal icon ""))
+                                          (not (string-equal title "")))
+                                 (propertize " " 'face 'variable-pitch))
+                               (when title (propertize title 'face face)))
+                         :help-echo help
+                         :action action
+                         :mouse-face 'highlight
+                         :button-prefix prefix
+                         :button-suffix suffix
+                         :format "%[%t%]")
+          (insert " ")))
+      (let* ((width (current-column)))
+        (beginning-of-line)
+        (dashboard-center-line (make-string width ?\s))
+        (end-of-line))
+      (insert "\n"))
+    (insert "\n")))
 
 (defmacro dashboard-insert-section (section-name list list-size shortcut action &rest widget-params)
   "Add a section with SECTION-NAME and LIST of LIST-SIZE items to the dashboard.


### PR DESCRIPTION
Fix #148 .

```elisp
;; Format: "(icon title help action face prefix suffix")
(setq dashboard-navigator-buttons
      `(;; line1
        ((,(all-the-icons-octicon "mark-github" :height 1.1 :v-adjust 0.0)
         "Homepage"
         "Browse homepage"
         (lambda (&rest _) (browse-url "homepage")))
        ("★" "Star" "Show stars" (lambda (&rest _) (show-stars)) warning)
        ("?" "" "?/h" #'show-help nil "<" ">"))
         ;; line 2
        ((,(all-the-icons-faicon "linkedin" :height 1.1 :v-adjust 0.0)
          "Linkedin"
          ""
          (lambda (&rest _) (browse-url "homepage")))
         ("⚑" nil "Show flags" (lambda (&rest _) (message "flag")) error))))
```

![image](https://user-images.githubusercontent.com/140797/59049674-1c812b80-88bb-11e9-8c09-378714b93481.png)
