### PR TITLE
Text startup banner.

### DIFF
--- a/README.org
+++ b/README.org
@@ -63,7 +63,7 @@ To update the banner or banner title
 ;; 'official which displays the official emacs logo
 ;; 'logo which displays an alternative emacs logo
 ;; 1, 2 or 3 which displays one of the text banners
-;; "path/to/your/image.png" which displays whatever image you would prefer
+;; "path/to/your/image.png" or "path/to/your/text.txt" which displays whatever image/text you would prefer
 
 ;; Content is not centered by default. To center, set
 (setq dashboard-center-content t)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -86,9 +86,11 @@ to the specified width, with aspect ratio preserved."
   (expand-file-name (concat dashboard-banners-directory "logo.png"))
   "Emacs banner image.")
 
-(defvar dashboard-banner-logo-text
+(defcustom dashboard-banner-logo-text
   (expand-file-name (concat dashboard-banners-directory "1.txt"))
-  "Emacs banner text.")
+  "Emacs banner text."
+  :type 'string
+  :group 'dashboard)
 
 (defconst dashboard-banner-length 75
   "Width of a banner.")

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -86,6 +86,10 @@ to the specified width, with aspect ratio preserved."
   (expand-file-name (concat dashboard-banners-directory "logo.png"))
   "Emacs banner image.")
 
+(defvar dashboard-banner-logo-text
+  (expand-file-name (concat dashboard-banners-directory "1.txt"))
+  "Emacs banner text.")
+
 (defconst dashboard-banner-length 75
   "Width of a banner.")
 
@@ -353,7 +357,10 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 
 (defun dashboard-get-banner-path (index)
   "Return the full path to banner with index INDEX."
-  (concat dashboard-banners-directory (format "%d.txt" index)))
+  (if (and dashboard-banner-logo-text
+           (file-exists-p dashboard-banner-logo-text))
+      dashboard-banner-logo-text
+    (concat dashboard-banners-directory (format "%d.txt" index))))
 
 (defun dashboard-choose-banner ()
   "Return the full path of a banner based on the dotfile value."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -141,7 +141,7 @@ Example:
 Default value is `official', it displays
 the Emacs logo.  `logo' displays Emacs alternative logo.
 An integer value is the index of text
-banner.  A string value must be a path to a .PNG file.
+banner.  A string value must be a path to a .PNG or .TXT file.
 If the value is nil then no banner is displayed.")
 
 (defvar dashboard-buffer-last-width nil

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -86,12 +86,6 @@ to the specified width, with aspect ratio preserved."
   (expand-file-name (concat dashboard-banners-directory "logo.png"))
   "Emacs banner image.")
 
-(defcustom dashboard-banner-logo-text
-  (expand-file-name (concat dashboard-banners-directory "1.txt"))
-  "Emacs banner text."
-  :type 'string
-  :group 'dashboard)
-
 (defconst dashboard-banner-length 75
   "Width of a banner.")
 
@@ -359,10 +353,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 
 (defun dashboard-get-banner-path (index)
   "Return the full path to banner with index INDEX."
-  (if (and dashboard-banner-logo-text
-           (file-exists-p dashboard-banner-logo-text))
-      dashboard-banner-logo-text
-    (concat dashboard-banners-directory (format "%d.txt" index))))
+  (concat dashboard-banners-directory (format "%d.txt" index)))
 
 (defun dashboard-choose-banner ()
   "Return the full path of a banner based on the dotfile value."
@@ -377,10 +368,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
              (dashboard-get-banner-path 1)))
           ((integerp dashboard-startup-banner)
            (dashboard-get-banner-path dashboard-startup-banner))
-          ((and dashboard-startup-banner
-                (image-type-available-p (intern (file-name-extension
-                                                 dashboard-startup-banner)))
-                (display-graphic-p))
+          ((stringp dashboard-startup-banner)
            (if (file-exists-p dashboard-startup-banner)
                dashboard-startup-banner
              (message (format "could not find banner %s"


### PR DESCRIPTION
This is a quick implementation for text banner. See #153. The benefits are this is down compatible if the user want to use default `1.txt`, `2.txt` and `3.txt` banner files. Otherwise, they can just set the `dashboard-banner-logo-text` variable like the line of code below. If they want the default banner just set to nil.

```el
(setq dashboard-banner-logo-text "dir/banner.txt")
```

**Edit:** This implementation may not be the best solution, because I don't know what the author of `dashboard` wants. So I guess this PR is just an advice.