### PR TITLE
Replace `seq-take` with its code

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -147,7 +147,8 @@ Optional prefix ARG says how many lines to move; default is one line."
         (recentf-is-on (recentf-enabled-p))
         (origial-recentf-list recentf-list)
         (dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0))
-        (max-line-length 0))
+        (max-line-length 0)
+        (recentf-items '()))
     ;; disable recentf mode,
     ;; so we don't flood the recent files list with org mode files
     ;; do this by making a copy of the part of the list we'll use
@@ -156,11 +157,10 @@ Optional prefix ARG says how many lines to move; default is one line."
     ;; (this avoids many saves/loads that would result from
     ;; disabling/enabling recentf-mode)
     (if recentf-is-on
-        (setq recentf-list (let ((result '()))
-                             (while (and recentf-list (> n 0))
-                               (setq n (1- n))
-                               (push (pop recentf-list) result))
-                             (nreverse result))))
+        (setq recentf-list
+              (nreverse (while (and recentf-list (> dashboard-num-recents 0))
+                          (setq dashboard-num-recents (1- dashboard-num-recents))
+                          (push (pop recentf-list) recentf-items)))))
     (when (or (not (eq dashboard-buffer-last-width (window-width)))
               (not buffer-exists))
       (setq dashboard-banner-length (window-width)

--- a/dashboard.el
+++ b/dashboard.el
@@ -156,8 +156,11 @@ Optional prefix ARG says how many lines to move; default is one line."
     ;; (this avoids many saves/loads that would result from
     ;; disabling/enabling recentf-mode)
     (if recentf-is-on
-        (setq recentf-list (seq-take recentf-list dashboard-num-recents))
-      )
+        (setq recentf-list (let ((result '()))
+                             (while (and recentf-list (> n 0))
+                               (setq n (1- n))
+                               (push (pop recentf-list) result))
+                             (nreverse result))))
     (when (or (not (eq dashboard-buffer-last-width (window-width)))
               (not buffer-exists))
       (setq dashboard-banner-length (window-width)


### PR DESCRIPTION
Replace `seq-take` call with its code, to avoid adding `(require seq)`.

Fix #152 