### PR TITLE
Reduce initial requires

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -619,6 +619,7 @@ date part is considered."
 (defun dashboard-insert-agenda (list-size)
   "Add the list of LIST-SIZE items of agenda."
   (require 'org-agenda)
+  (require 'calendar)
   (let ((agenda (dashboard-get-agenda)))
     (dashboard-insert-section
      (or (and (boundp 'show-week-agenda-p) show-week-agenda-p "Agenda for the coming week:")

--- a/dashboard.el
+++ b/dashboard.el
@@ -20,11 +20,8 @@
 
 ;;; Code:
 
-(require 'bookmark)
-(require 'calendar)
 (require 'page-break-lines)
 (require 'recentf)
-(require 'register)
 
 (require 'dashboard-widgets)
 


### PR DESCRIPTION
Do not require `bookmarks`, `calendar` and `register` initially. Instead, they are loaded when needed by a widget.

Partially solve #159 