### PR TITLE
Added filtering by category for org mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -166,6 +166,12 @@ To show agenda for the upcoming seven days set the variable ~show-week-agenda-p~
 
 Note that setting list-size for the agenda list is intentionally ignored; all agenda items for the current day will be displayed.
 
+To customize which categories from the agenda items should be visible in the dashboard set the ~dashboard-org-agenda-categories~ to the list of categories you need.
+
+#+BEGIN_SRC elisp
+(setq dashboard-org-agenda-categories '("Tasks" "Appointments"))
+ #+END_SRC
+
 ** Faces
 
 It is possible to customize Dashboard's appearance using the following faces:

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -73,6 +73,13 @@ to the specified width, with aspect ratio preserved."
   :type 'boolean
   :group 'dashboard)
 
+(defcustom dashboard-org-agenda-categories nil
+  "Specify the Categories to consider when using agenda in dashboard.
+Example:
+'(\"Tasks\" \"Habits\")"
+  :type 'list
+  :group 'dashboard)
+
 (defconst dashboard-banners-directory
   (concat (file-name-directory
            (locate-library "dashboard"))
@@ -98,11 +105,6 @@ The format is: 'icon title help action face prefix suffix'.
 
 Example:
 '((\"☆\" \"Star\" \"Show stars\" (lambda (&rest _) (show-stars)) 'warning \"[\" \"]\"))")
-
-(defvar dashboard-org-agenda-categories nil
-  "Specify the Categories to consider when using agenda in dashboard.
-Example:
-'(\"Tasks\" \"Habits\")")
 
 
 

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -99,6 +99,13 @@ The format is: 'icon title help action face prefix suffix'.
 Example:
 '((\"☆\" \"Star\" \"Show stars\" (lambda (&rest _) (show-stars)) 'warning \"[\" \"]\"))")
 
+(defvar dashboard-org-agenda-categories nil
+  "Specify the Categories to consider when using agenda in dashboard.
+Example:
+'(\"Tasks\" \"Habits\")")
+
+
+
 (defvar dashboard-init-info
   ;; Check if package.el was loaded and if package loading was enabled
   (if (bound-and-true-p package-alist)
@@ -606,12 +613,14 @@ date part is considered."
                        t))
                 (loc (point))
                 (file (buffer-file-name)))
-           (when (and (not (org-entry-is-done-p))
-                      (or (and schedule-time (dashboard-date-due-p schedule-time due-date))
-                          (and deadline-time (dashboard-date-due-p deadline-time due-date))))
-             (setq filtered-entries
-                   (append filtered-entries
-                           (list (list item schedule-time deadline-time loc file)))))))
+           (if (or (equal dashboard-org-agenda-categories nil)
+                   (member (org-get-category) dashboard-org-agenda-categories))
+               (when (and (not (org-entry-is-done-p))
+                          (or (and schedule-time (dashboard-date-due-p schedule-time due-date))
+                              (and deadline-time (dashboard-date-due-p deadline-time due-date))))
+                 (setq filtered-entries
+                       (append filtered-entries
+                               (list (list item schedule-time deadline-time loc file))))))))
        nil
        'agenda)
       filtered-entries)))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -106,8 +106,6 @@ The format is: 'icon title help action face prefix suffix'.
 Example:
 '((\"☆\" \"Star\" \"Show stars\" (lambda (&rest _) (show-stars)) 'warning \"[\" \"]\"))")
 
-
-
 (defvar dashboard-init-info
   ;; Check if package.el was loaded and if package loading was enabled
   (if (bound-and-true-p package-alist)


### PR DESCRIPTION
Added support for filtering by category in dashboard, so the users can now select the org categories which they wants to have in the dashboard. 
The users would have to specify the category which they need in their dashboard, or if they don't all categories will be considered.

So in my config I have something like this:

```
(use-package dashboard
  :ensure t
  :config
(setq dashboard-items '((recents . 10) (bookmarks . 5) (agenda . 10)))
  (setq dashboard-org-agenda-categories '("Tasks"))
  (dashboard-setup-startup-hook))
 
```