### PR TITLE
Use dashboard-buffer-name everywhere when invoking buffers

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -252,7 +252,7 @@ Optionally, provide NO-NEXT-LINE to move the cursor forward a line."
 (defun dashboard-append (msg &optional _messagebuf)
   "Append MSG to dashboard buffer.
 If MESSAGEBUF is not nil then MSG is also written in message buffer."
-  (with-current-buffer (get-buffer-create "*dashboard*")
+  (with-current-buffer (get-buffer-create dashboard-buffer-name)
     (goto-char (point-max))
     (let ((buffer-read-only nil))
       (insert msg))))

--- a/dashboard.el
+++ b/dashboard.el
@@ -247,7 +247,7 @@ assume a filename and skip displaying Dashboard."
                                      ;; Display useful lists of items
                                      (dashboard-insert-startupify-lists)))
         (add-hook 'emacs-startup-hook '(lambda ()
-                                         (switch-to-buffer "*dashboard*")
+                                         (switch-to-buffer dashboard-buffer-name)
                                          (goto-char (point-min))
                                          (redisplay))))))
 


### PR DESCRIPTION
This takes care of #176 and makes it easier to customize for users.