### PR TITLE
Disable display-line-numbers-model

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -56,6 +56,8 @@
   (buffer-disable-undo)
   (whitespace-mode -1)
   (linum-mode -1)
+  (when (>= emacs-major-version 26)
+    (display-line-numbers-mode -1))
   (page-break-lines-mode 1)
   (setq inhibit-startup-screen t)
   (setq buffer-read-only t


### PR DESCRIPTION
This is a short ~~one~~two-liner commit to add support for hiding line numbers by default for users of `global-display-line-numbers-mode`, the way they are hidden for users of `global-linum-mode`. It checks the major version first, since the new mode was added in Emacs 26. 