### PR TITLE
(draft) Adds option to always start in the background & hide modeline in DB buffer

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -56,7 +56,7 @@
   (whitespace-mode -1)
   (linum-mode -1)
   (if (>= emacs-major-version 26)
-      (display-line-numbers-mode -1))
+	  (display-line-numbers-mode -1))
   (page-break-lines-mode 1)
   (setq inhibit-startup-screen t)
   (setq buffer-read-only t
@@ -241,17 +241,26 @@ Optional prefix ARG says how many lines to move; default is one line."
 ;;;###autoload
 (defun dashboard-setup-startup-hook ()
   "Setup post initialization hooks.
-If a command line argument is provided,
-assume a filename and skip displaying Dashboard."
-  (if (< (length command-line-args) 2 )
-      (progn
-        (add-hook 'after-init-hook (lambda ()
-                                     ;; Display useful lists of items
-                                     (dashboard-insert-startupify-lists)))
-        (add-hook 'emacs-startup-hook '(lambda ()
-                                         (switch-to-buffer "*dashboard*")
-                                         (goto-char (point-min))
-                                         (redisplay))))))
+By default, if a command line argument is provided,
+assume a filename and skip displaying Dashboard. If the
+user chooses, start the dashboard anyway."
+  (if (or (boundp 'dashboard-always-start) (< (length command-line-args) 2 ))
+	  (progn
+		(add-hook 'after-init-hook (lambda ()
+									 ;; Display useful lists of items
+									 (dashboard-insert-startupify-lists)))
+		(add-hook 'emacs-startup-hook '(lambda ()
+										 (switch-to-buffer "*dashboard*")
+										 (goto-char (point-min))
+										 (if (boundp 'dashboard-hide-modeline)
+											 (setq mode-line-format nil))
+										 (if (= (length command-line-args) 1 )
+											 (redisplay))
+										 (if (> (length command-line-args) 1 )
+											 (switch-to-buffer (nth 0 (last (split-string (nth 1 command-line-args) "/"))))))))))
+
+
+
 
 (provide 'dashboard)
 ;;; dashboard.el ends here

--- a/dashboard.el
+++ b/dashboard.el
@@ -55,8 +55,6 @@
   :abbrev-table nil
   (whitespace-mode -1)
   (linum-mode -1)
-  (if (>= emacs-major-version 26)
-      (display-line-numbers-mode -1))
   (page-break-lines-mode 1)
   (setq inhibit-startup-screen t)
   (setq buffer-read-only t
@@ -248,21 +246,21 @@ assume a filename and skip displaying Dashboard.  If the
 user chooses, start the dashboard anyway."
   (if (or (boundp 'dashboard-always-start) (< (length command-line-args) 2 ))
       (progn
-        (add-hook 'after-init-hook (lambda ()
-                                     ;; Display useful lists of items
-                                     (dashboard-insert-startupify-lists)))
-        (add-hook 'emacs-startup-hook '(lambda ()
-                                         (switch-to-buffer "*dashboard*")
-                                         (goto-char (point-min))
-                                         (if (boundp 'dashboard-hide-modeline)
-                                             (setq mode-line-format nil))
-                                         (if (= (length command-line-args) 1 )
-                                             (redisplay))
-                                         (if (> (length command-line-args) 1 )
-                                             (switch-to-buffer (nth 0 (last (split-string (nth 1 command-line-args) "/"))))))))))
-
-
-
+        (add-hook 'after-init-hook
+                  (lambda ()
+                    ;; Display useful lists of items
+                    (dashboard-insert-startupify-lists)))
+        (add-hook 'emacs-startup-hook
+                  '(lambda ()
+                     (switch-to-buffer "*dashboard*")
+                     (goto-char (point-min))
+                     (if (boundp 'dashboard-hide-modeline)
+                         (setq mode-line-format nil))
+                     (if (= (length command-line-args) 1 )
+                         (redisplay))
+                     (if (> (length command-line-args) 1 )
+                         (switch-to-buffer
+                          (nth 0 (last (split-string (nth 1 command-line-args) "/"))))))))))
 
 (provide 'dashboard)
 ;;; dashboard.el ends here

--- a/dashboard.el
+++ b/dashboard.el
@@ -56,7 +56,7 @@
   (whitespace-mode -1)
   (linum-mode -1)
   (if (>= emacs-major-version 26)
-	  (display-line-numbers-mode -1))
+      (display-line-numbers-mode -1))
   (page-break-lines-mode 1)
   (setq inhibit-startup-screen t)
   (setq buffer-read-only t
@@ -227,7 +227,9 @@ Optional prefix ARG says how many lines to move; default is one line."
   (interactive)
   (kill-buffer dashboard-buffer-name)
   (dashboard-insert-startupify-lists)
-  (switch-to-buffer dashboard-buffer-name))
+  (switch-to-buffer dashboard-buffer-name)
+  (if (boundp 'dashboard-hide-modeline)
+      (setq mode-line-format nil)))
 
 (defun dashboard-resize-on-hook (&optional _)
   "Re-render dashboard on window size change."
@@ -242,22 +244,22 @@ Optional prefix ARG says how many lines to move; default is one line."
 (defun dashboard-setup-startup-hook ()
   "Setup post initialization hooks.
 By default, if a command line argument is provided,
-assume a filename and skip displaying Dashboard. If the
+assume a filename and skip displaying Dashboard.  If the
 user chooses, start the dashboard anyway."
   (if (or (boundp 'dashboard-always-start) (< (length command-line-args) 2 ))
-	  (progn
-		(add-hook 'after-init-hook (lambda ()
-									 ;; Display useful lists of items
-									 (dashboard-insert-startupify-lists)))
-		(add-hook 'emacs-startup-hook '(lambda ()
-										 (switch-to-buffer "*dashboard*")
-										 (goto-char (point-min))
-										 (if (boundp 'dashboard-hide-modeline)
-											 (setq mode-line-format nil))
-										 (if (= (length command-line-args) 1 )
-											 (redisplay))
-										 (if (> (length command-line-args) 1 )
-											 (switch-to-buffer (nth 0 (last (split-string (nth 1 command-line-args) "/"))))))))))
+      (progn
+        (add-hook 'after-init-hook (lambda ()
+                                     ;; Display useful lists of items
+                                     (dashboard-insert-startupify-lists)))
+        (add-hook 'emacs-startup-hook '(lambda ()
+                                         (switch-to-buffer "*dashboard*")
+                                         (goto-char (point-min))
+                                         (if (boundp 'dashboard-hide-modeline)
+                                             (setq mode-line-format nil))
+                                         (if (= (length command-line-args) 1 )
+                                             (redisplay))
+                                         (if (> (length command-line-args) 1 )
+                                             (switch-to-buffer (nth 0 (last (split-string (nth 1 command-line-args) "/"))))))))))
 
 
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -55,6 +55,7 @@
   :abbrev-table nil
   (whitespace-mode -1)
   (linum-mode -1)
+  (display-line-numbers-mode -1)
   (page-break-lines-mode 1)
   (setq inhibit-startup-screen t)
   (setq buffer-read-only t

--- a/dashboard.el
+++ b/dashboard.el
@@ -55,7 +55,8 @@
   :abbrev-table nil
   (whitespace-mode -1)
   (linum-mode -1)
-  (display-line-numbers-mode -1)
+  (if (>= emacs-major-version 26)
+      (display-line-numbers-mode -1))
   (page-break-lines-mode 1)
   (setq inhibit-startup-screen t)
   (setq buffer-read-only t


### PR DESCRIPTION
I'm still working on using `magit` effectively, but I have works in progress that may be of interest. 

This adds two parameters, `dashboard-always-start` and `dashboard-hide-modeline`, to `dashboard-setup-startup-hook`. 

If `dashboard-always-start` is enabled then the dashboard buffer will be created even when Emacs is called on a file from the command line, but Emacs will immediately switch to the file's buffer after initializing the dashboard without further input from the user. I'm not the most familiar with how Emacs names its buffers, so it's possible a certain configuration could break this. The current method chops the `command-line-args` list down to just the filename and attempts to switch to the buffer with that name. It makes it more IDE like, for those who would want that. Failed tests are due to the length of the line. 

If `dashboard-hide-modeline` is enabled then the modeline will disappear from the dashboard but not other buffers. It results in a cleaner look overall, but unfortunately only temporarily. Occasionally Emacs does something to put it back, for example starting treemacs or asking the user to accept local variables in elisp files. I'm still looking at how to make it hide the modeline again automatically. One interesting thing is that hiccups that bring the modeline back for the dashboard don't seem to do the same for treemacs.  