### PR TITLE
fix "invalid face property: inherit nil" on navigator icons

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -440,10 +440,11 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
           (widget-create 'item
                          :tag (concat
                                (when icon
-                                 (propertize icon 'face `(:inherit
-                                                          ,(get-text-property 0 'face icon)
-                                                          :inherit
-                                                          ,face)))
+                                 (propertize icon 'face
+                                             (let ((prop-face (get-text-property 0 'face icon)))
+                                               (if prop-face
+                                                   `(:inherit ,prop-face :inherit ,face)
+                                                 `(:inherit ,face)))))
                                (when (and icon title
                                           (not (string-equal icon ""))
                                           (not (string-equal title "")))


### PR DESCRIPTION
this request addresses issue [191](https://github.com/emacs-dashboard/emacs-dashboard/issues/191). It's a small change and logically identical to before, only now there's an extra `nil` check to ensure the text isn't propertized with an invalid face property. 😄.