### PR TITLE
Fix space after comma for phrase in dashboard-footer

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -151,7 +151,7 @@ Example:
                 "Welcome to the church of Emacs"
                 "While any text editor can save your files,\
  only Emacs can save your soul"
-                "I showed you my source code,pls respond"
+                "I showed you my source code, pls respond"
                 )))
     (nth (random (1- (1+ (length list)))) list))
   "A footer with some short message.")


### PR DESCRIPTION
Space after comma: "I showed you my source code, pls respond" to "I showed you my source code, pls respond".