### PR TITLE
Fix error when `dashboard--section-starts' is nil

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -203,7 +203,8 @@ Optional prefix ARG says how many lines to move; default is one line."
                     (dashboard-insert-page-break)))
                 dashboard-items)
           (when dashboard-center-content
-            (goto-char (car (last dashboard--section-starts)))
+            (when dashboard--section-starts
+              (goto-char (car (last dashboard--section-starts))))
             (let ((margin (floor (/ (max (- (window-width) max-line-length) 0)  2))))
               (while (not (eobp))
                 (and (not (eq ? (char-after)))


### PR DESCRIPTION
If you set `dashboard-items` to nil, `dashboard--section-starts' is nil. The current code tries to get the car of `dashboard--section-starts' and will raise an error if it is nil. This pull request simply checks if `dashboard--section-starts` is nil before getting the car.