### PR TITLE
Fix error when calling dashboard-previous-section before any section

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -89,9 +89,10 @@
       (when (and (not current-section-start)
                  (< elt current-position))
         (setq current-section-start elt)))
-    (goto-char (if (eq current-position current-section-start)
-                   previous-section-start
-                 current-section-start))))
+    (goto-char (or (when (eq current-position current-section-start)
+                     previous-section-start)
+                   current-section-start
+                   current-position))))
 
 (defun dashboard-next-section ()
   "Navigate forward to next section."


### PR DESCRIPTION
Place the cursor on "Welcome to Emacs!" or just anywhere before the first section, then run `dashboard-previous-section` --- it will error out (at `goto-char`) complaining that nil is not a number or marker. This is caused by the current version not checking if local variables `previous-section-start` or `current-section-start` are non-nil (unlike `dashboard-next-section`).

This PR fixes that by making `dashboard-previous-section` fall back to jumping to the current position (effectively doing nothing) when both `previous-section-start` and `next-section-start` are nil.