### PR TITLE
Revert "Fix error when `dashboard--section-starts' is nil"

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -204,8 +204,7 @@ Optional prefix ARG says how many lines to move; default is one line."
                     (dashboard-insert-page-break)))
                 dashboard-items)
           (when dashboard-center-content
-            (when dashboard--section-starts
-              (goto-char (car (last dashboard--section-starts))))
+            (goto-char (car (last dashboard--section-starts)))
             (let ((margin (floor (/ (max (- (window-width) max-line-length) 0)  2))))
               (while (not (eobp))
                 (and (not (eq ? (char-after)))


### PR DESCRIPTION
Reverts emacs-dashboard/emacs-dashboard#204