### PR TITLE
Align the file icons horizontally

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -20,9 +20,13 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 ;; Compiler pacifier
 (declare-function all-the-icons-icon-for-dir "ext:all-the-icons.el")
 (declare-function all-the-icons-icon-for-file "ext:all-the-icons.el")
+(declare-function all-the-icons-fileicon "ext:all-the-icons.el")
+(declare-function all-the-icons-octicon "ext:all-the-icons.el")
 (declare-function bookmark-get-filename "ext:bookmark.el")
 (declare-function bookmark-all-names "ext:bookmark.el")
 (declare-function calendar-date-compare "ext:calendar.el")
@@ -548,7 +552,8 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
                              (all-the-icons-octicon "primitive-dot" :height 1.0 :v-adjust 0.01))
                             ((file-remote-p path)
                              (all-the-icons-octicon "radio-tower" :height 1.0 :v-adjust 0.01))
-                            (t (all-the-icons-icon-for-file (file-name-nondirectory path)))))))
+                            (t (all-the-icons-icon-for-file (file-name-nondirectory path)
+                                                            :v-adjust -0.05))))))
               (setq tag (concat icon " " ,@rest))))
 
           (widget-create 'item

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -25,8 +25,6 @@
 ;; Compiler pacifier
 (declare-function all-the-icons-icon-for-dir "ext:all-the-icons.el")
 (declare-function all-the-icons-icon-for-file "ext:all-the-icons.el")
-(declare-function all-the-icons-fileicon "ext:all-the-icons.el")
-(declare-function all-the-icons-octicon "ext:all-the-icons.el")
 (declare-function bookmark-get-filename "ext:bookmark.el")
 (declare-function bookmark-all-names "ext:bookmark.el")
 (declare-function calendar-date-compare "ext:calendar.el")


### PR DESCRIPTION
Align the file icons horizontally in dashboard.
Also fix compiler warnings.