### PR TITLE
Check if *dashboard* buffer exists or not.

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -227,7 +227,8 @@ Optional prefix ARG says how many lines to move; default is one line."
 (defun dashboard-refresh-buffer ()
   "Refresh buffer."
   (interactive)
-  (kill-buffer dashboard-buffer-name)
+  (when (get-buffer dashboard-buffer-name)
+    (kill-buffer dashboard-buffer-name))
   (dashboard-insert-startupify-lists)
   (switch-to-buffer dashboard-buffer-name))
 


### PR DESCRIPTION
Sometimes we may have accidentally killed the `\*dashboard\*` buffer.  And then `(kill-buffer dashboard-buffer-name)` will not work and give out an error.  Thus, when the buffer not exists, we can ignore the `kill-buffer` step.