### PR TITLE
User specified time formatting in org-agenda

### DIFF
--- a/README.org
+++ b/README.org
@@ -176,7 +176,7 @@ To customize which categories from the agenda items should be visible in the das
  ~time-string-formatting~ to a formatting accepted by `format-time-string` (see the internal
  documentation for the function or the [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Time-Parsing.html][online documentation]] for a list of valid formattings). For
  example, to display the date and month (using the three letter code), set ~time-string-formatting~
- to ~"%e %b"~.
+ to ~%e %b~.
 
 ** Faces
 

--- a/README.org
+++ b/README.org
@@ -172,6 +172,12 @@ To customize which categories from the agenda items should be visible in the das
 (setq dashboard-org-agenda-categories '("Tasks" "Appointments"))
  #+END_SRC
 
+ To use an alternate formatting for the date of upcoming events, set the variable
+ ~time-string-formatting~ to a formatting accepted by `format-time-string` (see the internal
+ documentation for the function or the [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Time-Parsing.html][online documentation]] for a list of valid formattings). For
+ example, to display the date and month (using the three letter code), set ~time-string-formatting~
+ to ~"%e %b"~.
+
 ** Faces
 
 It is possible to customize Dashboard's appearance using the following faces:

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -662,7 +662,7 @@ date part is considered."
 (defun dashboard-get-agenda ()
   "Get agenda items for today or for a week from now."
   (if (not (boundp 'time-string-formatting))
-      (setq time-string-formatting "%Y-%m-%d")
+      (defvar time-string-formatting "%Y-%m-%d")
       )
   (org-compile-prefix-format 'agenda)
   (let ((due-date nil))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -44,6 +44,7 @@
 (declare-function org-outline-level "ext:org.el")
 (defvar all-the-icons-dir-icon-alist)
 (defvar package-activated-list)
+(defvar time-string-formatting)
 
 (defcustom dashboard-page-separator "\n\f\n"
   "Separator to use between the different pages."
@@ -662,8 +663,8 @@ date part is considered."
 (defun dashboard-get-agenda ()
   "Get agenda items for today or for a week from now."
   (if (not (boundp 'time-string-formatting))
-      (defvar time-string-formatting "%Y-%m-%d")
-      )
+      (setq time-string-formatting "%Y-%m-%d")
+    )
   (org-compile-prefix-format 'agenda)
   (let ((due-date nil))
     (if (and (boundp 'show-week-agenda-p) show-week-agenda-p)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -661,6 +661,9 @@ date part is considered."
 
 (defun dashboard-get-agenda ()
   "Get agenda items for today or for a week from now."
+  (if (not (boundp 'time-string-formatting))
+      (setq time-string-formatting "%Y-%m-%d")
+      )
   (org-compile-prefix-format 'agenda)
   (let ((due-date nil))
     (if (and (boundp 'show-week-agenda-p) show-week-agenda-p)
@@ -673,7 +676,7 @@ date part is considered."
          (let* ((schedule-time (org-get-scheduled-time (point)))
                 (deadline-time (org-get-deadline-time (point)))
                 (item (org-agenda-format-item
-                       (format-time-string "%Y-%m-%d" schedule-time)
+                       (format-time-string time-string-formatting schedule-time)
                        (org-get-heading t t)
                        (org-outline-level)
                        (org-get-category)


### PR DESCRIPTION
Added an option for the user to specify the formatting for the time displayed in org-agenda.