### PR TITLE
Define custom function to switch to a project.

### DIFF
--- a/README.org
+++ b/README.org
@@ -160,6 +160,18 @@ To customize it and customize its icon;
                                                    :face 'font-lock-keyword-face))
 #+END_SRC
 
+To use it with [[https://github.com/ericdanan/counsel-projectile][counsel-projectile]] or [[https://github.com/bbatsov/persp-projectile][persp-projectile]]
+
+#+begin_src elisp
+(setq dashboard-projects-switch-function 'counsel-projectile-switch-project-by-name)
+#+end_src
+
+Or
+
+#+begin_src elisp
+(setq dashboard-projects-switch-function 'projectile-persp-switch-project)
+#+end_src
+
 ** Org mode’s agenda
 
    To display today’s agenda items on the dashboard, add ~agenda~ to ~dashboard-items~:


### PR DESCRIPTION
Add `dashboard-projectile-switch-function` to custom variables, a function use when switching to projectile projects.

By default is `projectile-switch-project-by-name` but it can be change to `counsel-projectile-switch-project-by-name`, in this case to solve #215 and in my case `projectile-persp-switch-project`.