### PR TITLE
Add option to open projects with magit

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -250,6 +250,12 @@ If nil it is disabled.  Possible values for list-type are:
   :type  '(repeat (alist :key-type symbol :value-type string))
   :group 'dashboard)
 
+(defcustom dashboard-projectile-vc nil
+  "When non nil, `dashboard-return' opens `vc-dir' (with
+  `magit-status' if available) at the root of the project."
+  :type 'boolean
+  :group 'dashboard)
+
 (defvar recentf-list nil)
 
 ;;
@@ -627,7 +633,12 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
                      0 list-size)
    list-size
    "p"
-   `(lambda (&rest ignore) (projectile-switch-project-by-name ,el))
+   `(lambda (&rest ignore)
+      (if dashboard-projectile-vc
+          (let ((magit-display-buffer-function
+                 'magit-display-buffer-same-window-except-diff-v1))
+            (projectile-vc ,el))
+        (projectile-switch-project-by-name ,el)))
    (abbreviate-file-name el)))
 
 ;;


### PR DESCRIPTION
I would like to start to work on a project with magit. Before this PR, i was opening a random file and then open magit. It works for me now.

This PR is similar to #232 

Maybe something like this on that PR would work same (did not test yet):
```lisp
(setq dashboard-projectile-switch-function
      (lambda (arg) (let ((magit-display-buffer-function
                           'magit-display-buffer-same-window-except-diff-v1))
                      (projectile-vc arg))))
```