### PR TITLE
Agenda refactor

### DIFF
--- a/README.org
+++ b/README.org
@@ -176,6 +176,15 @@ To customize which categories from the agenda items should be visible in the das
 (setq dashboard-org-agenda-categories '("Tasks" "Appointments"))
  #+END_SRC
 
+To have an extra filter, ~MATCH~ parameter is exposed as
+~dashboard-match-agenda-entry~ variable, by default is ~nil~
+#+begin_quote
+‘MATCH’ is a tags/property/TODO match. Org iterates only matched
+headlines. Org iterates over all headlines when MATCH is nil or t.
+#+end_quote
+
+See [[https://www.gnu.org/software/emacs/manual/html_node/org/Using-the-mapping-API.html][Org Manual]] for more information.
+
 ** Faces
 
 It is possible to customize Dashboard's appearance using the following faces:

--- a/README.org
+++ b/README.org
@@ -163,9 +163,9 @@ To customize it and customize its icon;
 (add-to-list 'dashboard-items '(agenda) t)
 #+END_SRC
 
-To show agenda for the upcoming seven days set the variable ~show-week-agenda-p~ to ~t~.
+To show agenda for the upcoming seven days set the variable ~dashboard-week-agenda~ to ~t~.
 #+BEGIN_SRC elisp
-(setq show-week-agenda-p t)
+(setq dashboard-week-agenda t)
 #+END_SRC
 
 Note that setting list-size for the agenda list is intentionally ignored; all agenda items for the current day will be displayed.

--- a/README.org
+++ b/README.org
@@ -176,6 +176,14 @@ To customize which categories from the agenda items should be visible in the das
 (setq dashboard-org-agenda-categories '("Tasks" "Appointments"))
  #+END_SRC
 
+By default org-agenda entries are filter by time, only showing those
+task with ~DEADLINE~ or ~SCHEDULE-TIME~. To show all agenda entries
+(except ~DONE~)
+
+#+begin_src elisp
+(setq dashboard-filter-agenda-entry dashboard-no-filter-agenda)
+#+end_src
+
 To have an extra filter, ~MATCH~ parameter is exposed as
 ~dashboard-match-agenda-entry~ variable, by default is ~nil~
 #+begin_quote

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -669,21 +669,19 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
 ;;
 ;; Org Agenda
 ;;
-(defcustom dashboard-week-agenda
-  t
-  "Show agenda weekly."
+(defcustom dashboard-week-agenda t
+  "Show agenda weekly if its not nil."
   :type 'boolean
   :group 'dashboard)
 
-(defcustom dashboard-agenda-time-string-format
-  "%Y-%m-%d"
+(defcustom dashboard-agenda-time-string-format "%Y-%m-%d"
   "Format time of agenda entries."
   :type 'string
   :group 'dashboard)
 
-(defcustom dashboard-match-agenda-entry
-  nil
-  "Match agenda to extra filter."
+(defcustom dashboard-match-agenda-entry nil
+  "Match agenda to extra filter.
+It is the MATCH attribute for `org-map-entries'"
   :type 'string
   :group 'dashboard)
 

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -672,14 +672,19 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
   :type 'boolean
   :group 'dashboard)
 
+(defcustom dashboard-match-agenda-entry
+  nil
+  "Match agenda to extra filter."
+  :type 'string
+  :group 'dashboard)
+
 (defun dashboard-format-agenda-entry ()
   "Format agenda entry to show it on dashboard."
   (let* ((schedule-time (org-get-scheduled-time (point)))
          (deadline-time (org-get-deadline-time (point)))
          (item (org-agenda-format-item
-                (format-time-string "%Y-%m-%d"
-                                    schedule-time)
-                (org-get-heading t t)
+                (format-time-string "%Y-%m-%d" schedule-time)
+                (org-get-heading)
                 (org-outline-level)
                 (org-get-category)
                 (org-get-tags)
@@ -711,7 +716,9 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
 (defun dashboard-get-agenda ()
   "Get agenda items for today or for a week from now."
   (org-compile-prefix-format 'agenda)
-  (org-map-entries `dashboard-format-agenda-entry t 'agenda
+  (org-map-entries `dashboard-format-agenda-entry
+                   dashboard-match-agenda-entry
+                   'agenda
                    `dashboard-filter-agenda-entry))
 
 (defun dashboard-insert-agenda (list-size)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -690,11 +690,17 @@ date part is considered."
     (calendar-date-compare (list gregorian-date)
                            (list gregorian-due-date))))
 
+(defcustom dashboard-week-agenda
+  t
+  "Show agenda weekly."
+  :type 'boolean
+  :group 'dashboard)
+
 (defun dashboard-get-agenda ()
   "Get agenda items for today or for a week from now."
   (org-compile-prefix-format 'agenda)
   (let ((due-date nil))
-    (if (and (boundp 'show-week-agenda-p) show-week-agenda-p)
+    (if dashboard-week-agenda
         (setq due-date (time-add (current-time) (* 86400 7)))
       (setq due-date nil)
       )
@@ -730,8 +736,9 @@ date part is considered."
   (require 'calendar)
   (let ((agenda (dashboard-get-agenda)))
     (dashboard-insert-section
-     (or (and (boundp 'show-week-agenda-p) show-week-agenda-p "Agenda for the coming week:")
-         "Agenda for today:")
+     (if dashboard-week-agenda
+         "Agenda for the coming week:"
+       "Agenda for today:")
      agenda
      list-size
      (dashboard-get-shortcut 'agenda)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -42,6 +42,9 @@
 (declare-function org-get-tags "ext:org.el")
 (declare-function org-map-entries "ext:org.el")
 (declare-function org-outline-level "ext:org.el")
+;; Org-time-less-p is define in emacs-27 as time-less-p alias
+(when (< emacs-major-version 27)
+  (defalias 'org-time-less-p 'time-less-p))
 (defvar all-the-icons-dir-icon-alist)
 (defvar package-activated-list)
 


### PR DESCRIPTION
Commits to refactor the agenda widget.
It show all agenda entries, expose `org-map-entries` `MATCH` parameter.
Allow time format.