### PR TITLE
Add dashboard-after-initialize-hook to run after initialization

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -48,8 +48,10 @@
     map)
   "Keymap for dashboard mode.")
 
-(defvar dashboard-after-initialize-hook nil
-  "Hook that is run after dashboard buffer is initialized.")
+(defcustom dashboard-after-initialize-hook nil
+  "Hook that is run after dashboard buffer is initialized."
+  :group 'dashboard
+  :type 'hook)
 
 (define-derived-mode dashboard-mode special-mode "Dashboard"
   "Dashboard major mode for startup screen.

--- a/dashboard.el
+++ b/dashboard.el
@@ -48,6 +48,9 @@
     map)
   "Keymap for dashboard mode.")
 
+(defvar dashboard-after-initialize-hook nil
+  "Hook that is run after dashboard buffer is initialized.")
+
 (define-derived-mode dashboard-mode special-mode "Dashboard"
   "Dashboard major mode for startup screen.
 \\<dashboard-mode-map>
@@ -255,7 +258,8 @@ assume a filename and skip displaying Dashboard."
     (add-hook 'emacs-startup-hook '(lambda ()
                                      (switch-to-buffer dashboard-buffer-name)
                                      (goto-char (point-min))
-                                     (redisplay)))))
+                                     (redisplay)
+                                     (run-hooks 'dashboard-after-initialize-hook)))))
 
 (provide 'dashboard)
 ;;; dashboard.el ends here


### PR DESCRIPTION
This could be useful to delay loading of some packages or any time consuming processes to end of the dashboard initialization.

Loading some big packages with this hook reduced my init time (init of dashboard screen actually) from 1.8s to 1.3s. Emacs does not respond before run-hooks finished of course but this feels much faster and I look to the dashboard for a sec anyway. So I think this is an improvement.