### PR TITLE
Allow txt when graphical.

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -498,10 +498,10 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
            (dashboard-get-banner-path dashboard-startup-banner))
           ((stringp dashboard-startup-banner)
            (if (and (file-exists-p dashboard-startup-banner)
-                    (if (display-graphic-p)
-                        (image-type-available-p (intern (file-name-extension
-                                                         dashboard-startup-banner)))
-                      (string-suffix-p ".txt" dashboard-startup-banner)))
+                    (or (string-suffix-p ".txt" dashboard-startup-banner)
+                        (and (display-graphic-p)
+                             (image-type-available-p (intern (file-name-extension
+                                                              dashboard-startup-banner))))))
                dashboard-startup-banner
              (message "could not find banner %s, use default instead" dashboard-startup-banner)
              (dashboard-get-banner-path 1)))


### PR DESCRIPTION
Logic error, fix not allowing text inside terminal.

See #153.