### PR TITLE
Bugfix dashboard-filter-agenda-by-time.

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -779,13 +779,12 @@ if returns a point."
   (let ((schedule-time (org-get-scheduled-time (point)))
         (deadline-time (org-get-deadline-time (point)))
         (due-date (dashboard-due-date-for-agenda)))
-    (if (or (org-entry-is-done-p)
-            (and (null schedule-time)
-                 (null deadline-time))
-            (not (or (org-time-less-p deadline-time due-date)
-                     (org-time-less-p schedule-time due-date))))
-        (point)
-      nil)))
+    (unless (and (not (org-entry-is-done-p))
+                 (or (and schedule-time
+                          (org-time-less-p schedule-time due-date))
+                     (and deadline-time
+                          (org-time-less-p deadline-time due-date))))
+      (point))))
 
 (defun dashboard-no-filter-agenda ()
   "No filter agenda entries."


### PR DESCRIPTION
Solves #266
When schedule-time or deadline-time is nil but not both,
org-time-less-p treat them as current-date. Filter will skip the entry
unless it's not done and has schedule time less than due date or has a
deadline time less than due date.

There are other ways to express this condition
```ruby
(when (or (org-entry-is-done-p)
          (and (or (null schedule-time)
                   (org-time-less-p due-date schedule-time))
               (or (null deadline-time)
                   (org-time-less-p due-date deadline-time))))
  (point))
```
Or
```ruby
(cond
  ((org-entry-is-done-p) (point))
  ((and schedule-time
        (org-time-less-p schedule-time due-date)) nil)
  ((and deadline-time
        (org-time-less-p deadline-time due-date)) nil)
  (t (point)))
```