### PR TITLE
Respect to custom items face instead of widget-button face

### DIFF
--- a/README.org
+++ b/README.org
@@ -220,7 +220,7 @@ It is possible to customize Dashboard's appearance using the following faces:
      Highlights text banners.
 - ~dashboard-heading~ ::
      Highlights widget headings.
-- ~widget-button~ ::
+- ~dashboard-items~ ::
      Highlights widget items.
 
 * Shortcuts

--- a/README.org
+++ b/README.org
@@ -220,7 +220,7 @@ It is possible to customize Dashboard's appearance using the following faces:
      Highlights text banners.
 - ~dashboard-heading~ ::
      Highlights widget headings.
-- ~dashboard-items~ ::
+- ~dashboard-items-face~ ::
      Highlights widget items.
 
 * Shortcuts

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -298,6 +298,11 @@ If nil it is disabled.  Possible values for list-type are:
   "Face used for widget headings."
   :group 'dashboard)
 
+(defface dashboard-items
+  '((t (:inherit widget-button)))
+  "Face used for items."
+  :group 'dashboard)
+
 (defface dashboard-no-items
   '((t (:inherit widget-button)))
   "Face used for no items."
@@ -537,7 +542,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                                (when title (propertize title 'face face)))
                          :help-echo help
                          :action action
-                         :button-face 'widget-button
+                         :button-face 'dashboard-items
                          :mouse-face 'highlight
                          :button-prefix prefix
                          :button-suffix suffix
@@ -599,7 +604,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
           (widget-create 'item
                          :tag tag
                          :action ,action
-                         :button-face 'widget-button
+                         :button-face 'dashboard-items
                          :mouse-face 'highlight
                          :button-prefix ""
                          :button-suffix ""

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -298,12 +298,12 @@ If nil it is disabled.  Possible values for list-type are:
   "Face used for widget headings."
   :group 'dashboard)
 
-(defface dashboard-items
+(defface dashboard-items-face
   '((t (:inherit widget-button)))
   "Face used for items."
   :group 'dashboard)
 
-(defface dashboard-no-items
+(defface dashboard-no-items-face
   '((t (:inherit widget-button)))
   "Face used for no items."
   :group 'dashboard)
@@ -542,7 +542,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                                (when title (propertize title 'face face)))
                          :help-echo help
                          :action action
-                         :button-face 'dashboard-items
+                         :button-face 'dashboard-items-face
                          :mouse-face 'highlight
                          :button-prefix prefix
                          :button-suffix suffix
@@ -571,7 +571,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
                      ,@widget-params)
                     ,shortcut)
            (dashboard-insert-shortcut ,shortcut ,section-name))
-       (insert (propertize "\n    --- No items ---" 'face 'dashboard-no-items)))))
+       (insert (propertize "\n    --- No items ---" 'face 'dashboard-no-items-face)))))
 
 ;;
 ;; Section list
@@ -604,7 +604,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
           (widget-create 'item
                          :tag tag
                          :action ,action
-                         :button-face 'dashboard-items
+                         :button-face 'dashboard-items-face
                          :mouse-face 'highlight
                          :button-prefix ""
                          :button-suffix ""


### PR DESCRIPTION
The discussion here, https://github.com/emacs-dashboard/emacs-dashboard/commit/d7921414dd47ea8eeaa2631cb15f75e31c485eb7.

`widget-button` face is widely use, I think we should create our own custom face to prevent tweaking `widget-button` face.