### PR TITLE
Add truncate style for path

### DIFF
--- a/Cask
+++ b/Cask
@@ -5,5 +5,4 @@
 (files "*.el" "*.org" "banners")
 
 (development
- (depends-on "page-break-lines")
- (depends-on "f"))
+ (depends-on "page-break-lines"))

--- a/Cask
+++ b/Cask
@@ -5,4 +5,5 @@
 (files "*.el" "*.org" "banners")
 
 (development
- (depends-on "page-break-lines"))
+ (depends-on "page-break-lines")
+ (depends-on "f"))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -737,8 +737,9 @@ switch to."
   "Add the list of LIST-SIZE items of projects."
   (dashboard-insert-section
    "Projects:"
-   (dashboard-shorten-paths (dashboard-subseq (dashboard-projects-backend-load-projects) 0 list-size)
-                            'dashboard-projects-alist)
+   (dashboard-shorten-paths
+    (dashboard-subseq (dashboard-projects-backend-load-projects) 0 list-size)
+    'dashboard-projects-alist)
    list-size
    (dashboard-get-shortcut 'projects)
    `(lambda (&rest ignore)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -655,6 +655,14 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
 ;;
 ;; Truncate
 ;;
+(defun dashboard-f-filename (path)
+  "Return file name from PATH."
+  (file-name-nondirectory path))
+
+(defun dashboard-f-base (path)
+  "Return directory name from PATH."
+  (file-name-nondirectory (directory-file-name (file-name-directory path))))
+
 (defun dashboard-shorten-path-beginning (path)
   "Shorten PATH from beginning if exceeding maximum length."
   (let* ((len-path (length path)) (len-rep (length dashboard-path-shorten-string))
@@ -748,7 +756,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
    (let ((file (dashboard-expand-path-alist el dashboard-recentf-alist))
          (path (dashboard-extract-key-path-alist el dashboard-recentf-alist)))
      (if dasbhoard-recentf-show-base
-         (format dasbhoard-recentf-item-format (f-filename file) path)
+         (format dasbhoard-recentf-item-format (dashboard-f-filename file) path)
        path))))
 
 ;;
@@ -811,7 +819,7 @@ switch to."
    (let ((file (dashboard-expand-path-alist el dashboard-projects-alist))
          (path (dashboard-extract-key-path-alist el dashboard-projects-alist)))
      (if dasbhoard-projects-show-base
-         (format dasbhoard-projects-item-format ((f-base file)) path)
+         (format dasbhoard-projects-item-format (dashboard-f-base file) path)
        path))))
 
 (defun dashboard-projects-backend-load-projects ()

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -23,7 +23,6 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'f)
 
 ;; Compiler pacifier
 (declare-function all-the-icons-icon-for-dir "ext:all-the-icons.el")

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -652,7 +652,6 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
 ;;
 ;; Truncate
 ;;
-
 (defun dashboard-shorten-path-by-length (path)
   "Shorten the PATH by length."
   (let* ((len-path (length path)) (len-rep (length dashboard-path-shorten-string))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -694,16 +694,19 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
   (recentf-mode)
   (dashboard-insert-section
    "Recent Files:"
-   (dashboard-shorten-paths recentf-list 'dashboard-recentf-alist)
+   recentf-list
    list-size
    (dashboard-get-shortcut 'recents)
    `(lambda (&rest ignore)
       (find-file-existing (cdr (assoc ,el dashboard-recentf-alist))))
-   (abbreviate-file-name el)))
+   (dashboard-shorten-path el)))
 
 ;;
 ;; Bookmarks
 ;;
+(defvar dashboard-bookmark-alist nil
+  "Alist records shorten's recent files and it's full paths.")
+
 (defun dashboard-insert-bookmarks (list-size)
   "Add the list of LIST-SIZE items of bookmarks."
   (require 'bookmark)
@@ -715,7 +718,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
    `(lambda (&rest ignore) (bookmark-jump ,el))
    (let ((file (bookmark-get-filename el)))
      (if file
-         (format "%s - %s" el (abbreviate-file-name file))
+         (format "%s - %s" el (dashboard-shorten-path file))
        el))))
 
 ;;
@@ -737,15 +740,13 @@ switch to."
   "Add the list of LIST-SIZE items of projects."
   (dashboard-insert-section
    "Projects:"
-   (dashboard-shorten-paths
-    (dashboard-subseq (dashboard-projects-backend-load-projects) 0 list-size)
-    'dashboard-projects-alist)
+   (dashboard-subseq (dashboard-projects-backend-load-projects) 0 list-size)
    list-size
    (dashboard-get-shortcut 'projects)
    `(lambda (&rest ignore)
       (funcall (dashboard-projects-backend-switch-function)
                (cdr (assoc ,el dashboard-projects-alist))))
-   (abbreviate-file-name el)))
+   (dashboard-shorten-path el)))
 
 (defun dashboard-projects-backend-load-projects ()
   "Depending on `dashboard-projects-backend' load corresponding backend.

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'f)
 
 ;; Compiler pacifier
 (declare-function all-the-icons-icon-for-dir "ext:all-the-icons.el")

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -674,7 +674,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
     (t path)))
 
 (defun dashboard-shorten-paths (paths alist)
-  "Shorten all path from PATHS."
+  "Shorten all path from PATHS and store it to ALIST."
   (let (lst-display abbrev)
     (setf (symbol-value alist) nil)  ; reset
     (dolist (item paths)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -694,12 +694,12 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
   (recentf-mode)
   (dashboard-insert-section
    "Recent Files:"
-   recentf-list
+   (dashboard-shorten-paths recentf-list 'dashboard-recentf-alist)
    list-size
    (dashboard-get-shortcut 'recents)
    `(lambda (&rest ignore)
       (find-file-existing (cdr (assoc ,el dashboard-recentf-alist))))
-   (dashboard-shorten-path el)))
+   (abbreviate-file-name el)))
 
 ;;
 ;; Bookmarks
@@ -740,13 +740,15 @@ switch to."
   "Add the list of LIST-SIZE items of projects."
   (dashboard-insert-section
    "Projects:"
-   (dashboard-subseq (dashboard-projects-backend-load-projects) 0 list-size)
+   (dashboard-shorten-paths
+    (dashboard-subseq (dashboard-projects-backend-load-projects) 0 list-size)
+    'dashboard-projects-alist)
    list-size
    (dashboard-get-shortcut 'projects)
    `(lambda (&rest ignore)
       (funcall (dashboard-projects-backend-switch-function)
                (cdr (assoc ,el dashboard-projects-alist))))
-   (dashboard-shorten-path el)))
+   (abbreviate-file-name el)))
 
 (defun dashboard-projects-backend-load-projects ()
   "Depending on `dashboard-projects-backend' load corresponding backend.

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -273,9 +273,15 @@ If nil it is disabled.  Possible values for list-type are:
   :type  '(repeat (alist :key-type symbol :value-type string))
   :group 'dashboard)
 
+(defcustom dashboard-path-style nil
+  "Style to display path."
+  :type '(choice (const :tag "No specify" nil)
+                 (const :tag "Truncate by length" truncate-length))
+  :group 'dashboard)
+
 (defcustom dashboard-path-max-length 70
   "Maximum length for path to display."
-  :type 'string
+  :type 'integer
   :group 'dashboard)
 
 (defcustom dashboard-path-shorten-string "..."
@@ -646,9 +652,9 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
 ;;
 ;; Truncate
 ;;
-(defun dashboard-shorten-path (path)
-  "Shorten the PATH."
-  (setq path (abbreviate-file-name path))
+
+(defun dashboard-shorten-path-by-length (path)
+  "Shorten the PATH by length."
   (let* ((len-path (length path)) (len-rep (length dashboard-path-shorten-string))
          (len-total (- dashboard-path-max-length len-rep))
          (center (/ len-total 2))
@@ -659,6 +665,13 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
       (setq back (substring path 0 end-back)
             front (substring path start-front len-path))
       (concat back dashboard-path-shorten-string front))))
+
+(defun dashboard-shorten-path (path)
+  "Shorten the PATH."
+  (setq path (abbreviate-file-name path))
+  (cl-case dashboard-path-style
+    (truncate-length (dashboard-shorten-path-by-length path))
+    (t path)))
 
 (defun dashboard-shorten-paths (paths alist)
   "Shorten all path from PATHS."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -728,7 +728,7 @@ WIDGET-PARAMS are passed to the \"widget-create\" function."
   (cdr (assoc key alist)))
 
 (defun dashboard--generate-align-format (fmt len)
-  "Return inserted align LEN to FMT."
+  "Return FMT after inserting align LEN."
   (let ((pos (1+ (string-match-p "%s" fmt))))
     (concat (substring fmt 0 pos)
             (concat "-" (number-to-string len))

--- a/dashboard.el
+++ b/dashboard.el
@@ -14,7 +14,7 @@
 ;; Created: October 05, 2016
 ;; Package-Version: 1.8.0-SNAPSHOT
 ;; Keywords: startup, screen, tools, dashboard
-;; Package-Requires: ((emacs "25.3") (page-break-lines "0.11"))
+;; Package-Requires: ((emacs "25.3") (page-break-lines "0.11") (f "0.20.0"))
 ;;; Commentary:
 
 ;; An extensible Emacs dashboard, with sections for

--- a/dashboard.el
+++ b/dashboard.el
@@ -14,7 +14,7 @@
 ;; Created: October 05, 2016
 ;; Package-Version: 1.8.0-SNAPSHOT
 ;; Keywords: startup, screen, tools, dashboard
-;; Package-Requires: ((emacs "25.3") (page-break-lines "0.11") (f "0.20.0"))
+;; Package-Requires: ((emacs "25.3") (page-break-lines "0.11"))
 ;;; Commentary:
 
 ;; An extensible Emacs dashboard, with sections for


### PR DESCRIPTION
Hmmm... I have tried implements #276. I would say this is a frame so we can implement more styles in the future.

@JesusMtnez What do you think? 😕 

```el
(setq dashboard-path-style 'truncate-middle)
(setq dashboard-path-max-length 50)
```

<img src="https://user-images.githubusercontent.com/8685505/102754679-453b1a00-43a8-11eb-9dc9-848a9af09ed6.png" width="441" height="524"/>
