### PR TITLE
Clean up recentf list before insertion

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -779,7 +779,7 @@ If optional argument DIR is non-nil; align with directory name instead."
 (defun dashboard-insert-recents (list-size)
   "Add the list of LIST-SIZE items from recently edited files."
   (setq dashboard--recentf-cache-item-format nil)
-  (recentf-mode)
+  (recentf-mode) (recentf-cleanup)
   (dashboard-insert-section
    "Recent Files:"
    (dashboard-shorten-paths recentf-list 'dashboard-recentf-alist)


### PR DESCRIPTION
We need this or else it will insert empty the file path that has been deleted from disk.