### PR TITLE
Fix recent files show org agenda files issue

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -218,6 +218,8 @@ Optional prefix ARG says how many lines to move; default is one line."
                           (cdr-safe (assoc el dashboard-item-generators))))
                     (add-to-list 'dashboard--section-starts (point))
                     (funcall item-generator list-size)
+                    (when recentf-is-on
+                      (setq recentf-list origial-recentf-list))
                     (setq max-line-length
                           (max max-line-length (dashboard-maximum-section-length)))
                     (dashboard-insert-page-break)))


### PR DESCRIPTION
Hi, I have been using dashboard for a long time. Thanks for your amazing work and all the contributors.

Recently, I meet the issue that Recent Files show the org-agenda files.

I think #83 don't fix issue #51 perfectly.

#83 only works when the Emacs starts up the first time .

It won't works in the following situations:

1. press `g`(call `dashboard-refresh-buffer`) after you `kill-buffer` all your agenda files.

The reason here is #83 use `origial-recentf-list` to restore the `recentf-list` after ALL dashboard-items HAVE been rendered.
```
save recentf-list -> do agenda -> do other things -> do recentf -> restore recentf-list
```
I think the right thing is
```
save -> do agenda -> restore -> do other things -> restore -> do recentf -> restore
```
So I make this PR.