### PR TITLE
Optional page-break-lines.

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -14,7 +14,7 @@
 ;; Created: October 05, 2016
 ;; Package-Version: 1.8.0-SNAPSHOT
 ;; Keywords: startup, screen, tools, dashboard
-;; Package-Requires: ((emacs "25.3") (page-break-lines "0.11"))
+;; Package-Requires: ((emacs "25.3"))
 ;;; Commentary:
 
 ;; An extensible Emacs dashboard, with sections for
@@ -60,7 +60,7 @@
 (defvar all-the-icons-dir-icon-alist)
 (defvar package-activated-list)
 
-(defcustom dashboard-page-separator "\n\f\n"
+(defcustom dashboard-page-separator "\n\n"
   "Separator to use between the different pages."
   :type 'string
   :group 'dashboard)

--- a/dashboard.el
+++ b/dashboard.el
@@ -14,7 +14,7 @@
 ;; Created: October 05, 2016
 ;; Package-Version: 1.8.0-SNAPSHOT
 ;; Keywords: startup, screen, tools, dashboard
-;; Package-Requires: ((emacs "25.3") (page-break-lines "0.11"))
+;; Package-Requires: ((emacs "25.3"))
 ;;; Commentary:
 
 ;; An extensible Emacs dashboard, with sections for
@@ -24,7 +24,6 @@
 
 (require 'seq)
 (require 'recentf)
-
 (require 'dashboard-widgets)
 
 ;; Custom splash screen
@@ -62,7 +61,8 @@
   (linum-mode -1)
   (when (>= emacs-major-version 26)
     (display-line-numbers-mode -1))
-  (page-break-lines-mode 1)
+  (when (require 'page-break-lines nil t)
+    (page-break-lines-mode 1))
   (setq inhibit-startup-screen t
         buffer-read-only t
         truncate-lines t))


### PR DESCRIPTION
Hi, this is for #160

As @Luis-Henriquez-Perez said to keep the lines of page-break-lines it's needed to set `dashboard-page-separator` to "\n\f\n" and have installed page-break-lines (the hook is not needed).