### PR TITLE
Allow section headings to be customized

### DIFF
--- a/README.org
+++ b/README.org
@@ -99,6 +99,13 @@ To add your own custom widget is pretty easy, define your widget's callback func
 (add-to-list 'dashboard-items '(custom) t)
  #+END_SRC
 
+To modify the widget heading name:
+#+BEGIN_SRC elisp
+  (setq dashboard-item-names '(("Recent Files:" . "Recently opened files:")
+                               ("Agenda for today:" . "Today's agenda:")
+                               ("Agenda for the coming week:" . "Agenda:"))
+#+END_SRC
+
 To add icons to the widget headings and their items:
 #+BEGIN_SRC elisp
 (setq dashboard-set-heading-icons t)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -262,6 +262,17 @@ value is nil, that item's shortcut is disbaled.  See
   :type '(repeat (alist :key-type symbol :value-type string))
   :group 'dashboard)
 
+(defcustom dashboard-item-names nil
+  "Association list of item heading names.
+When an item is nil or not present, the default name is used.
+Will be of the form `(default-name . new-name)'.
+Possible values for default-name are:
+\"Recent Files:\" \"Bookmarks:\" \"Agenda for today:\",
+\"Agenda for the coming week:\" \"Registers:\" \"Projects:\"."
+  :type '(alist :key-type string :value-type string)
+  :options '("Recent Files:" "Bookmarks:" "Agenda for today:"
+             "Agenda for the coming week:" "Registers:" "Projects:"))
+
 (defcustom dashboard-items-default-length 20
   "Length used for startup lists with otherwise unspecified bounds.
 Set to nil for unbounded."
@@ -438,6 +449,8 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
     (insert " "))
 
   (insert (propertize heading 'face 'dashboard-heading))
+  (overlay-put (make-overlay (- (point) (length heading)) (point))
+               'display (or (cdr (assoc heading dashboard-item-names)) heading))
   (when shortcut (insert (format " (%s)" shortcut))))
 
 (defun dashboard-center-line (string)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -450,7 +450,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
     (insert " "))
 
   (insert (propertize heading 'face 'dashboard-heading))
-  
+
   ;; Turn the inserted heading into an overlay, so that we may freely change
   ;; its name without breaking any of the functions that expect the default name.
   ;; If there isn't a suitable entry in `dashboard-item-names',

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -450,8 +450,16 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
     (insert " "))
 
   (insert (propertize heading 'face 'dashboard-heading))
-  (overlay-put (make-overlay (- (point) (length heading)) (point))
-               'display (or (cdr (assoc heading dashboard-item-names)) heading))
+  
+  ;; Turn the inserted heading into an overlay, so that we may freely change
+  ;; its name without breaking any of the functions that expect the default name.
+  ;; If there isn't a suitable entry in `dashboard-item-names',
+  ;; we fallback to using HEADING.  In that case we still want it to be an
+  ;; overlay to maintain consistent behavior (such as the point movement)
+  ;; between modified and default headings.
+  (let ((ov (make-overlay (- (point) (length heading)) (point) nil t)))
+    (overlay-put ov 'display (or (cdr (assoc heading dashboard-item-names)) heading))
+    (overlay-put ov 'face 'dashboard-heading))
   (when shortcut (insert (format " (%s)" shortcut))))
 
 (defun dashboard-center-line (string)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -271,7 +271,8 @@ Possible values for default-name are:
 \"Agenda for the coming week:\" \"Registers:\" \"Projects:\"."
   :type '(alist :key-type string :value-type string)
   :options '("Recent Files:" "Bookmarks:" "Agenda for today:"
-             "Agenda for the coming week:" "Registers:" "Projects:"))
+             "Agenda for the coming week:" "Registers:" "Projects:")
+  :group 'dashboard)
 
 (defcustom dashboard-items-default-length 20
   "Length used for startup lists with otherwise unspecified bounds.


### PR DESCRIPTION
Closes #305 

Section headings can now be given custom names through `dashboard-item-names'.
Since this is done through overlays it doesn't break any function that expects
the headings to have their default names.

It would arguably be more elegant to adapt all of the aforementioned cases to
use a system that can handle any name, but the work necessary would be a lot
more extensive than this, and I don't know how much of the codebase one would
want to revamp to accommodate this single feature.