### PR TITLE
Update document for optional dependency

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,7 +21,7 @@ An extensible emacs startup screen showing you what's most important.
 * Dependencies
 You will need the following packages which are all available on Melpa:
 
-1. page-break-lines - [[https://github.com/purcell/page-break-lines]]
+1. (optional) page-break-lines - [[https://github.com/purcell/page-break-lines]]
 2. (optional) projectile - [[https://github.com/bbatsov/projectile]]
 3. (optional) all-the-icons - [[https://github.com/domtronn/all-the-icons.el]]
 


### PR DESCRIPTION
`page-break-lines` became optional dependency after PR #315.

Update the README file.

---

By the way, @JesusMtnez can you set me as a org owner? or grant me the push permission to this repo? I think this would be a lot easier for me to maintain it! Hope I am qualify enough for the permission! 😅 