### PR TITLE
feat: added support for gifs

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,7 +72,7 @@ To update the banner or banner title
 ;; 'official which displays the official emacs logo
 ;; 'logo which displays an alternative emacs logo
 ;; 1, 2 or 3 which displays one of the text banners
-;; "path/to/your/image.png" or "path/to/your/text.txt" which displays whatever image/text you would prefer
+;; "path/to/your/image.gif", "path/to/your/image.png" or "path/to/your/text.txt" which displays whatever gif/image/text you would prefer
 
 ;; Content is not centered by default. To center, set
 (setq dashboard-center-content t)
@@ -282,3 +282,4 @@ make install
 ** Prerequisites
 
   * [[https://github.com/cask/cask][Cask]]
+    

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -484,6 +484,10 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
     (put-text-property 0 (length ascii-banner) 'face 'dashboard-text-banner ascii-banner)
     (insert ascii-banner)))
 
+(defun dashboard--type-is-gif-p (image-path)
+  "Returns if image is a gif. string -> bool"
+  (eq 'gif (image-type image-path)))
+
 (defun dashboard-insert-image-banner (banner)
   "Display an image BANNER."
   (when (file-exists-p banner)
@@ -494,12 +498,15 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                     (when (> dashboard-image-banner-max-height 0)
                       (list :max-height dashboard-image-banner-max-height))))
            (spec
-            (if (image-type-available-p 'imagemagick)
-                (apply 'create-image banner 'imagemagick nil size-props)
-              (apply 'create-image banner nil nil
-                     (when (and (fboundp 'image-transforms-p)
-                                (memq 'scale (funcall 'image-transforms-p)))
-                       size-props))))
+            (cond ((dashboard--type-is-gif-p banner)
+                   (create-image banner))
+                  ((image-type-available-p 'imagemagick)
+                   (apply 'create-image banner 'imagemagick nil size-props))
+                  (t
+                   (apply 'create-image banner nil nil
+                          (when (and (fboundp 'image-transforms-p)
+                                     (memq 'scale (funcall 'image-transforms-p)))
+                            size-props)))))
            ;; TODO: For some reason, `elisp-lint' is reporting error void
            ;; function `image-size'.
            (size (when (fboundp 'image-size) (image-size spec)))
@@ -509,6 +516,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
       (insert "\n")
       (insert (make-string left-margin ?\ ))
       (insert-image spec)
+      (when (dashboard--type-is-gif-p banner) (image-animate spec 0 t))
       (insert "\n\n")
       (when title
         (dashboard-center-line title)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -485,7 +485,9 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
     (insert ascii-banner)))
 
 (defun dashboard--type-is-gif-p (image-path)
-  "Returns if image is a gif. string -> bool"
+  "Return if image is a gif.
+String -> bool.
+Argument IMAGE-PATH path to the image."
   (eq 'gif (image-type image-path)))
 
 (defun dashboard-insert-image-banner (banner)


### PR DESCRIPTION
# Goal
- Use gif as dashboard banner

# to do it
- verify if `banner` is a gif
- if yes, animate it
- **obs.:** to do so, I had to add a new way of setting `spec`, I'm not sure why but the way it was before, it was messing the gif quality.

# Example:

In my configs:
```lisp
(setq dashboard-startup-banner  "path/to/carlton.gif")
```
https://user-images.githubusercontent.com/11412209/134744050-b10904f3-5f6d-4fc7-aa77-882fabe6db5b.mp4

