### PR TITLE
Dashboard agenda sort

### DIFF
--- a/README.org
+++ b/README.org
@@ -217,6 +217,12 @@ Once the agenda appears in the dashboard, ~org-agenda-files~ stay
 open. With ~(setq dashboard-agenda-release-buffers t)~ the org files
 are close. Note that this could slow down the dashboard buffer refreshment.
 
+*** Agenda sort
+
+Agenda is now sorted with ~dashboard-agenda-sort-strategy~ following
+the idea of [[https://orgmode.org/worg/doc.html#org-agenda-sorting-strategy][org-agenda-sorting-strategy]]. Suported strategies are
+~time-up~, ~time-down~, ~todo-state-up~ and ~todo-state-down~
+
 ** Faces
 
 It is possible to customize Dashboard's appearance using the following faces:
@@ -284,4 +290,3 @@ make install
 ** Prerequisites
 
   * [[https://github.com/cask/cask][Cask]]
-    

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -1041,22 +1041,22 @@ It is the MATCH attribute for `org-map-entries'"
   :type 'boolean
   :group 'dashboard)
 
-(defun dashboard-agenda-entry-time (schedule-time)
-  "Format SCHEDULE-TIME with custom format.
-If SCHEDULE-TIME is nil returns a blank string which length
+(defun dashboard-agenda-entry-time (entry-time)
+  "Format ENTRY-TIME with custom format.
+If ENTRY-TIME is nil returns a blank string which length
 is todays date format."
-  (let* ((time (or schedule-time (org-today)))
+  (let* ((time (or entry-time (org-today)))
          (formated-time (format-time-string
                          dashboard-agenda-time-string-format time)))
-    (if schedule-time
+    (if entry-time
         formated-time
       (replace-regexp-in-string "." " " formated-time))))
 
 (defun dashboard-agenda-entry-format ()
   "Format agenda entry to show it on dashboard."
-  (let* ((schedule-time (org-get-scheduled-time (point)))
+  (let* ((scheduled-time (org-get-scheduled-time (point)))
          (deadline-time (org-get-deadline-time (point)))
-         (entry-time (or schedule-time deadline-time))
+         (entry-time (or scheduled-time deadline-time))
          (item (org-agenda-format-item
                 (dashboard-agenda-entry-time entry-time)
                 (org-get-heading)
@@ -1095,15 +1095,15 @@ Do nothing if `TEXT' has already a face property or is nil."
     (time-add (current-time) 86400)))
 
 (defun dashboard-filter-agenda-by-time ()
-  "Include entry if it has a schedule-time or deadline-time in the future.
+  "Include entry if it has a scheduled-time or deadline-time in the future.
 An entry is included if this function returns nil and excluded
 if returns a point."
-  (let ((schedule-time (org-get-scheduled-time (point)))
+  (let ((scheduled-time (org-get-scheduled-time (point)))
         (deadline-time (org-get-deadline-time (point)))
         (due-date (dashboard-due-date-for-agenda)))
     (unless (and (not (org-entry-is-done-p))
-                 (or (and schedule-time
-                          (org-time-less-p schedule-time due-date))
+                 (or (and scheduled-time
+                          (org-time-less-p scheduled-time due-date))
                      (and deadline-time
                           (org-time-less-p deadline-time due-date))))
       (point))))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -1041,9 +1041,19 @@ It is the MATCH attribute for `org-map-entries'"
   :type 'boolean
   :group 'dashboard)
 
-(defcustom dashboard-agenda-sort-strategy ()
-  "If not nil agenda is sorted."
-  :type 'list
+(defcustom dashboard-filter-agenda-entry 'dashboard-filter-agenda-by-time
+  "Function to filter `org-agenda' entries."
+  :type '(choice
+          (const :tag "No filter" dashboard-no-filter-agenda)
+          (const :tag "Filter by time" dashboard-filter-agenda-by-time)
+          (const :tag "Filter by todo" dashboard-filter-agenda-by-todo)
+          (function :tag "Custom function"))
+  :group 'dashboard)
+
+(defcustom dashboard-agenda-sort-strategy nil
+  "If nil agenda is not sorted. A list of strategies to sort the agenda."
+  :type '(repeat (choice (const time-up) (const time-down)
+                         (const todo-state-up) (const todo-state-down)))
   :group 'dashboard)
 
 (defun dashboard-agenda-entry-time (entry-time)
@@ -1127,15 +1137,6 @@ if returns a point."
 (defun dashboard-no-filter-agenda ()
   "No filter agenda entries."
   (when (org-entry-is-done-p) (point)))
-
-(defcustom dashboard-filter-agenda-entry 'dashboard-filter-agenda-by-time
-  "Function to filter `org-agenda' entries."
-  :type '(choice
-          (const :tag "No filter" dashboard-no-filter-agenda)
-          (const :tag "Filter by time" dashboard-filter-agenda-by-time)
-          (const :tag "Filter by todo" dashboard-filter-agenda-by-todo)
-          (function :tag "Custom function"))
-  :group 'dashboard)
 
 (defun dashboard-get-agenda ()
   "Get agenda items for today or for a week from now."


### PR DESCRIPTION
Hi, this is for #326
In org there is [org-agenda-sorting-strategy](https://orgmode.org/worg/doc.html#org-agenda-sorting-strategy) to sort agenda entries.
This PR introduces `dashboard-agenda-sort-strategy` to define the list of strategies for sorting the agenda.
For example, in the case of sorting by time (scheduled) `(setq dashboard-agenda-sort-strategy '(time-up))` will put the entries with time indications first (early first).