### PR TITLE
correct straight.el package count

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -169,7 +169,7 @@ Example:
       (when (bound-and-true-p package-alist)
         (setq package-count (length package-activated-list)))
       (when (boundp 'straight--profile-cache)
-        (setq package-count (+ (hash-table-size straight--profile-cache) package-count)))
+        (setq package-count (+ (hash-table-count straight--profile-cache) package-count)))
       (if (zerop package-count)
           (format "Emacs started in %s" time)
         (format "%d packages loaded in %s" package-count time))))


### PR DESCRIPTION
In emacs the "size" of as hash table refers to how big the table
itself is.  In other words, its capacity.  "count" is for "the actual
number of entries".