### PR TITLE
Add ace-link-dashboard

### DIFF
--- a/ace-link-dashboard.el
+++ b/ace-link-dashboard.el
@@ -1,0 +1,44 @@
+;;; ace-link-dashboard.el -- Ace link for dashboard-mode
+;;; Commentary:
+;;; Code:
+(declare-function avy-with "ext:avy.el")
+(declare-function avy-process "ext:avy.el")
+(declare-function avy--style-fn "ext:avy.el")
+(declare-function avy-with "ext:avy.el")
+(declare-function widget-move "ext:wid-edit.el")
+(declare-function widget-at "ext:wid-edit.el")
+(declare-function widget-button-press "ext:wid-edit.el")
+
+(defvar avy-style nil "Originally defined in avy.el.")
+
+;;;###autoload
+(defun ace-link-dashboard ()
+  "Open a visible link in a `dashboard-mode' buffer."
+  (interactive)
+  (let ((pt (avy-with ace-link-dashboard
+              (avy-process
+               (mapcar #'cdr (ace-link--dashboard-collect))
+               (avy--style-fn avy-style)))))
+    (ace-link--dashboard-action pt)))
+
+(defun ace-link--dashboard-action (point)
+  "Call action at POINT when widget is selected."
+  (funcall 'widget-button-press point))
+
+(defun ace-link--dashboard-collect ()
+  "Collect all widgets in the current `dashboard-mode' buffer."
+  (save-excursion
+    (let ((previous-point (window-start))
+          (end (window-end))
+          (candidates nil)
+          (next-widget-point (lambda ()
+                               (progn (widget-move 1)
+                                      (point)))))
+      (goto-char (window-start))
+      (while (< previous-point (funcall next-widget-point))
+        (setq previous-point (point))
+        (push (cons (widget-at previous-point) previous-point) candidates))
+      (nreverse candidates))))
+
+(provide 'ace-link-dashboard)
+;;; ace-link-dashboard.el ends here

--- a/dashboard.el
+++ b/dashboard.el
@@ -86,6 +86,7 @@
   (when (featurep 'linum) (linum-mode -1))
   (when (featurep 'display-line-numbers) (display-line-numbers-mode -1))
   (when (featurep 'page-break-lines) (page-break-lines-mode 1))
+  (when (featurep 'avy) (require 'ace-link-dashboard))
   (setq-local revert-buffer-function #'dashboard-refresh-buffer)
   (setq inhibit-startup-screen t
         buffer-read-only t


### PR DESCRIPTION
Hi, this is for #346 
This doesn't depend on [ace-link](https://github.com/abo-abo/ace-link), just depends on [avy](https://github.com/abo-abo/avy) and still has to set a key: 
```emacs-lisp
(define-key dashboard-map (kbd "l") 'ace-link-dashboard)
```
