### PR TITLE
Use `string-width` to compute the width of the dashboard footer

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -475,7 +475,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 (defun dashboard-center-line (string)
   "Center a STRING accoring to it's size."
   (insert (make-string (max 0 (floor (/ (- dashboard-banner-length
-                                           (+ (length string) 1)) 2))) ?\ )))
+                                           (+ (string-width string) 1)) 2))) ?\ )))
 
 ;;
 ;; BANNER


### PR DESCRIPTION
`length` cannot compute the width of a string on display, so the footer may not be at the center of the screen  when its language is not English, 