### PR TITLE
Use n, p to move up and down; use uppercase keys to jump to widgets

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -252,15 +252,15 @@ If nil it is disabled.  Possible values for list-type are:
   :group 'dashboard)
 
 (defcustom dashboard-item-shortcuts
-  '((recents   . "r")
-    (bookmarks . "m")
-    (projects  . "p")
-    (agenda    . "a")
-    (registers . "e"))
+  '((recents   . "R")
+    (bookmarks . "M")
+    (projects  . "P")
+    (agenda    . "A")
+    (registers . "E"))
   "Association list of items and their corresponding shortcuts.
 Will be of the form `(list-type . keys)' as understood by `(kbd keys)'.
 If nil, shortcuts are disabled.  If an entry's value is nil, that item's
-shortcut is disbaled.  See `dashboard-items' for possible values of list-type.'"
+shortcut is disabled.  See `dashboard-items' for possible values of list-type.'"
   :type '(repeat (alist :key-type symbol :value-type string))
   :group 'dashboard)
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -48,6 +48,8 @@
     (define-key map (kbd "<down>") 'dashboard-next-line)
     (define-key map (kbd "k") 'dashboard-previous-line)
     (define-key map (kbd "j") 'dashboard-next-line)
+    (define-key map (kbd "p") 'dashboard-previous-line)
+    (define-key map (kbd "n") 'dashboard-next-line)
     (define-key map [tab] 'widget-forward)
     (define-key map (kbd "C-i") 'widget-forward)
     (define-key map [backtab] 'widget-backward)


### PR DESCRIPTION
Hi, this is a proposed change to the dashboard hotkeys.

Cursor movement via n/p is not currently possible since p jumps to the Projects widget.  If we redefine the widget hotkeys (p, a, r, m, ...) to be uppercase, the p key is freed and we can use the standard special-mode keybindings (n, p) for moving point up and down.

Of course, feel free to reject this if it doesn't fit with the rest of dashboard!