### PR TITLE
Fixed issue wherein all previous entries showed.

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -1204,7 +1204,8 @@ point."
   (let ((scheduled-time (org-get-scheduled-time (point)))
         (deadline-time (org-get-deadline-time (point)))
         (entry-timestamp (dashboard-agenda--entry-timestamp (point)))
-        (due-date (dashboard-due-date-for-agenda)))
+        (due-date (dashboard-due-date-for-agenda))
+        (now (current-time)))
     (unless (and (not (org-entry-is-done-p))
                  (not (org-in-archived-heading-p))
                  (or (and scheduled-time
@@ -1212,7 +1213,15 @@ point."
                      (and deadline-time
                           (org-time-less-p deadline-time due-date))
                      (and entry-timestamp
-                          (org-time-less-p entry-timestamp due-date))))
+                          (org-time-less-p entry-timestamp due-date)))
+                 (or
+                    (org-entry-is-todo-p)
+                    (and scheduled-time
+                          (org-time-less-p now scheduled-time))
+                    (and deadline-time
+                          (org-time-less-p now deadline-time))
+                    (and entry-timestamp
+                          (org-time-less-p now entry-timestamp))))
       (point))))
 
 (defun dashboard-filter-agenda-by-todo ()

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -1213,15 +1213,8 @@ point."
                      (and deadline-time
                           (org-time-less-p deadline-time due-date))
                      (and entry-timestamp
-                          (org-time-less-p entry-timestamp due-date)))
-                 (or
-                    (org-entry-is-todo-p)
-                    (and scheduled-time
-                          (org-time-less-p now scheduled-time))
-                    (and deadline-time
-                          (org-time-less-p now deadline-time))
-                    (and entry-timestamp
-                          (org-time-less-p now entry-timestamp))))
+                          (org-time-less-p now entry-timestamp)
+                          (org-time-less-p entry-timestamp due-date))))
       (point))))
 
 (defun dashboard-filter-agenda-by-todo ()


### PR DESCRIPTION
Current function dashboard-filter-agenda-by-time allows all past agenda items to show.

This means all past items are passed.

This filters agenda items, and passes them only if an associated date is after current date.

This makes sure the items are relevant to the current time period, making sure they either start or end in the current week and not at some point in the past.