### PR TITLE
fix(dashboard-widget.el): Calculate path length in pixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Add capability to remove item for agenda (#372)
 * Add CI, activation test (#381)
 * Fix dashboard not showing up in daemon mode (#382)
+* Calculate truncate path length in pixel (#402)
 
 ## 1.7.0
 > Released Feb 21, 2020


### PR DESCRIPTION
Calculate string length in pixel instead of the function `(length ...)`.