### PR TITLE
Center banner with properties and combine text with image

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,10 +72,12 @@ To update the banner or banner title
 ;; Set the banner
 (setq dashboard-startup-banner [VALUE])
 ;; Value can be
-;; 'official which displays the official emacs logo
-;; 'logo which displays an alternative emacs logo
-;; 1, 2 or 3 which displays one of the text banners
-;; "path/to/your/image.gif", "path/to/your/image.png" or "path/to/your/text.txt" which displays whatever gif/image/text you would prefer
+;; - nil to display no banner
+;; - 'official which displays the official emacs logo
+;; - 'logo which displays an alternative emacs logo
+;; - 1, 2 or 3 which displays one of the text banners
+;; - "path/to/your/image.gif", "path/to/your/image.png" or "path/to/your/text.txt" which displays whatever gif/image/text you would prefer
+;; - a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
 
 ;; Content is not centered by default. To center, set
 (setq dashboard-center-content t)


### PR DESCRIPTION
This patch contains two (entangled) fixes:

1. Center the banner with text properties.
2. Display both the image and text banner at the same time, letting the frame pick the right one for the display type.

The first change, centering with text properties, ensures that the text is smoothly centered without flickering, even if the dashboard is displayed in multiple windows at the same time (each window will center independently).

I'm inserting both the text and image banner at the same time to ensure that we always get the correct banner. Before this change, creating the dashboard buffer before creating a GUI frame would display a text banner.

Known issue: This patch still has to pick whether to center by the image or by the text banner. It does this at redisplay time using a display conditional, but it gets a bit confused when switching back and forth between a terminal frame and a GUI frame.

fixes #386
fixes #197
related #388 (icons still aren't handled)