### PR TITLE
Added reference to dashboard-refresh-buffer  in readme file

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,6 +53,8 @@ activate the widget, set the variable =dashboard-projects-backend= to either
 available from GNU elpa), then add an entry like
 =(projects . 5)= to the variable =dashboard-items=.
 
+The function =dashboard-refresh-buffer= can be used to visit and refresh the dashboard.
+
 ** Emacs Daemon
 
 In addition to the above, configure =initial-buffer-choice= to show


### PR DESCRIPTION
I struggled trying to find how to display the dashboard. This adds one sentence to the readme with a reference to dashboard-refresh-buffer