### PR TITLE
dashboard-open

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,6 +34,8 @@ You will need the following packages which are all available on Melpa:
 M-x package-install RET dashboard
 #+END_SRC
 
+** Open the Dashboard
+You can set up the dashboard to open automatically at startup using =dashboard-setup-startup-hook=:
  #+BEGIN_SRC elisp
 (require 'dashboard)
 (dashboard-setup-startup-hook)
@@ -44,7 +46,9 @@ M-x package-install RET dashboard
   (dashboard-setup-startup-hook))
  #+END_SRC
 
-By default, this will show three lists, recent files and bookmarks and org-agenda items.
+Alternatively, if you don't want the dashboard to open by default, you can use the interactive function =dashboard-open= to open it when you do want it.
+
+By default, the dashboard will show three lists, recent files and bookmarks and org-agenda items.
 
 The widget “projects”, which shows a list of recent projects, is not enabled
 by default since it depends on packages that might not be available.  To
@@ -53,7 +57,7 @@ activate the widget, set the variable =dashboard-projects-backend= to either
 available from GNU elpa), then add an entry like
 =(projects . 5)= to the variable =dashboard-items=.
 
-The function =dashboard-refresh-buffer= can be used to visit and refresh the dashboard.
+The function =dashboard-refresh-buffer= (an alias for =dashboard-open=) can be used to visit and refresh the dashboard.
 
 ** Emacs Daemon
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -440,11 +440,15 @@ Optional argument ARGS adviced function arguments."
     (when recentf-is-on
       (setq recentf-list origial-recentf-list))))
 
-(defun dashboard-refresh-buffer (&rest _)
-  "Refresh buffer."
+
+;;;###autoload
+(defun dashboard-open (&rest _)
+  "Open (or refresh) the *dashboard* buffer."
   (interactive)
   (let ((dashboard-force-refresh t)) (dashboard-insert-startupify-lists))
   (switch-to-buffer dashboard-buffer-name))
+
+(defalias #'dashboard-refresh-buffer #'dashboard-open)
 
 ;;;###autoload
 (defun dashboard-setup-startup-hook ()


### PR DESCRIPTION
1) autoloading the `dashboard-refresh-buffer` function so it can be available before the dashboard has been displayed.
This should allow users to decide whether they want to display the dashboard by default at startup. If they don't, they can delay loading the whole package, and still be able to open the dashboard whenever they want

2) renaming `dashboard-refresh-buffer` to `dashboard-open` to better suggest the above use of the function. `dashboard-refresh-buffer` is kept as an alias for consistency and backwards compatibilty.