### PR TITLE
Fix spillover bug from #436

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -595,7 +595,7 @@ Argument IMAGE-PATH path to the image."
       ;; If specified, insert a text banner.
       (when-let (txt (plist-get banner :text))
         (if (eq dashboard-startup-banner 'ascii)
-            (insert txt)
+            (save-excursion (insert txt))
           (insert-file-contents txt))
         (put-text-property (point) (point-max) 'face 'dashboard-text-banner)
         (setq text-width 0)


### PR DESCRIPTION
See comments in #436.

Due to a discrepancy in point behavior between `insert` and `insert-file-contents`, `insert` must be called in a `save-excursion` block to ensure that the point remains unchanged.