### PR TITLE
Make the dashboard buffer read-only, as originally intended

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -461,7 +461,7 @@ Optionally, provide NO-NEXT-LINE to move the cursor forward a line."
 If MESSAGEBUF is not nil then MSG is also written in message buffer."
   (with-current-buffer (get-buffer-create dashboard-buffer-name)
     (goto-char (point-max))
-    (let (buffer-read-only) (insert msg))))
+    (let ((inhibit-read-only t)) (insert msg))))
 
 (defun dashboard-modify-heading-icons (alist)
   "Append ALIST items to `dashboard-heading-icons' to modify icons."

--- a/dashboard.el
+++ b/dashboard.el
@@ -374,7 +374,7 @@ Optional argument ARGS adviced function arguments."
   "Execute BODY in dashboard buffer."
   (declare (indent 0))
   `(with-current-buffer (get-buffer-create dashboard-buffer-name)
-     (let (buffer-read-only) ,@body)
+     (let ((inhibit-read-only t)) ,@body)
      (current-buffer)))
 
 (defun dashboard-maximum-section-length ()


### PR DESCRIPTION
This code was introduced before lexical binding was in use, so I suspect it used to work. Currently it causes the read-only status of the dashboard buffer to never be set, as only the lexical variable gets set instead.

I believe the original intention was to allow writing into the read-only buffer when generating it. `inhibit-read-only` should be a superior solution.