### PR TITLE
Adding ability and docs for icons in custom widget headers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # ignore generated files
 *.elc
+.DS_Store
 
 # eask packages
 .eask/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 
 # ignore generated files
 *.elc
-.DS_Store
 
 # eask packages
 .eask/

--- a/README.org
+++ b/README.org
@@ -110,6 +110,19 @@ To add your own custom widget is pretty easy, define your widget's callback func
 (add-to-list 'dashboard-items '(custom) t)
  #+END_SRC
 
+To add an icon to a custom widget, insert it with `dashboard-insert-heading` in your custom function.  In this example, there is an icon but no shortcut.
+#+BEGIN_SRC elisp
+(defun dashboard-insert-custom (list-size)
+  (dashboard-insert-heading "News:"
+                            nil
+                            (all-the-icons-faicon "newspaper-o"
+                                                  :height 1.2
+                                                  :v-adjust 0.0
+                                                  :face 'dashboard-heading))
+  (insert "\n")
+  (insert "    Custom text"))
+ #+END_SRC
+
 To modify the widget heading name:
 #+BEGIN_SRC elisp
   (setq dashboard-item-names '(("Recent Files:" . "Recently opened files:")

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -497,8 +497,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
              ((string-equal heading "Projects:")
               (all-the-icons-octicon (cdr (assoc 'projects dashboard-heading-icons))
                                      :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
-             ((not (null icon))
-              icon)
+             ((not (null icon)) icon)
              (t " ")))
     (insert " "))
 

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -472,8 +472,8 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   "Insert a page break line in dashboard buffer."
   (dashboard-append dashboard-page-separator))
 
-(defun dashboard-insert-heading (heading &optional shortcut)
-  "Insert a widget HEADING in dashboard buffer, adding SHORTCUT if provided."
+(defun dashboard-insert-heading (heading &optional shortcut icon)
+  "Insert a widget HEADING in dashboard buffer, adding SHORTCUT, ICON if provided."
   (when (and (dashboard-display-icons-p) dashboard-set-heading-icons)
     ;; Try loading `all-the-icons'
     (unless (or (fboundp 'all-the-icons-octicon)
@@ -497,6 +497,8 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
              ((string-equal heading "Projects:")
               (all-the-icons-octicon (cdr (assoc 'projects dashboard-heading-icons))
                                      :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
+             ((not (null icon))
+              icon)
              (t " ")))
     (insert " "))
 


### PR DESCRIPTION
Addressing #444, icons can be added to custom headers through an optional argument (which leaves the original `dashboard-insert-heading` function compatible and equally operational as before).

Also adds ignore to MacOS temp `.DS_Store` files.