### PR TITLE
feat(elpaca): provide a semantically correct init time in init info

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -181,6 +181,8 @@ Example:
       (when (boundp 'straight--profile-cache)
         (setq package-count (+ (hash-table-count straight--profile-cache) package-count)))
       (when (fboundp 'elpaca--queued)
+	(setq time (format "%f seconds" (float-time (time-subtract elpaca-after-init-time
+								   before-init-time))))
         (setq package-count (length (elpaca--queued))))
       (if (zerop package-count)
           (format "Emacs started in %s" time)


### PR DESCRIPTION
The reported time would be the time needed only to the queue the packages, not to actually process them.