### PR TITLE
add nerd-icons support to dashboard

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -268,36 +268,39 @@ predicate value."
   "Get the formatted icon for DIR.
 ARGS should be a plist containing `:height', `:v-adjust',
 or `:face' properties."
-  (cond ((eq dashboard-icon-type 'all-the-icons) (apply #'all-the-icons-icon-for-dir dir args))
-        ((eq dashboard-icon-type 'nerd-icons) (apply #'nerd-icons-icon-for-dir dir args))))
+  (pcase dashboard-icon-type
+    ('all-the-icons (apply #'all-the-icons-icon-for-dir dir args))
+    ('nerd-icons (apply #'nerd-icons-icon-for-dir dir args))))
 
 (defun dashboard-icon-for-file (file &rest args)
   "Get the formatted icon for FILE.
 ARGS should be a plist containing `:height', `:v-adjust',
 or `:face' properties."
-  (cond ((eq dashboard-icon-type 'all-the-icons) (apply #'all-the-icons-icon-for-file file args))
-        ((eq dashboard-icon-type 'nerd-icons) (apply #'nerd-icons-icon-for-file file args))))
+  (pcase dashboard-icon-type
+      ('all-the-icons (apply #'all-the-icons-icon-for-file file args))
+      ('nerd-icons (apply #'nerd-icons-icon-for-file file args))))
 
 (defun dashboard-octicon (name &rest args)
   "Get the formatted octicon.
 ARGS should be a plist containing `:height', `:v-adjust',
 or `:face' properties."
-  (cond ((eq dashboard-icon-type 'all-the-icons) (apply #'all-the-icons-octicon name args))
-        ((eq dashboard-icon-type 'nerd-icons) (apply #'nerd-icons-octicon name args))))
+  (pcase dashboard-icon-type
+    ('all-the-icons (apply #'all-the-icons-octicon name args))
+    ('nerd-icons (apply #'nerd-icons-octicon name args))))
 
 (defcustom dashboard-footer-icon
   (if (dashboard-display-icons-p)
-      (cond
-       ((eq dashboard-icon-type 'all-the-icons)
-        (all-the-icons-fileicon "emacs"
-                                :height 1.1
-                                :v-adjust -0.05
-                                :face 'font-lock-keyword-face))
-       ((eq dashboard-icon-type 'nerd-icons)
-        (nerd-icons-sucicon "nf-custom-emacs"
-                            :height 1.1
-                            :v-adjust -0.05
-                            :face 'font-lock-keyword-face)))
+      (pcase dashboard-icon-type
+        ('all-the-icons
+         (all-the-icons-fileicon "emacs"
+                                 :height 1.1
+                                 :v-adjust -0.05
+                                 :face 'font-lock-keyword-face))
+        ('nerd-icons
+         (nerd-icons-sucicon "nf-custom-emacs"
+                             :height 1.1
+                             :v-adjust -0.05
+                             :face 'font-lock-keyword-face)))
     (propertize ">" 'face 'dashboard-footer))
   "Footer's icon."
   :type 'string

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -69,6 +69,7 @@
 (defvar org-todo-keywords-1)
 (defvar all-the-icons-dir-icon-alist)
 (defvar package-activated-list)
+(defvar elpaca-after-init-time)
 (declare-function string-pixel-width "subr-x.el")   ; TODO: remove this after 29.1
 (declare-function shr-string-pixel-width "shr.el")  ; TODO: remove this after 29.1
 
@@ -181,8 +182,8 @@ Example:
       (when (boundp 'straight--profile-cache)
         (setq package-count (+ (hash-table-count straight--profile-cache) package-count)))
       (when (fboundp 'elpaca--queued)
-	(setq time (format "%f seconds" (float-time (time-subtract elpaca-after-init-time
-								   before-init-time))))
+        (setq time (format "%f seconds" (float-time (time-subtract elpaca-after-init-time
+                                                                   before-init-time))))
         (setq package-count (length (elpaca--queued))))
       (if (zerop package-count)
           (format "Emacs started in %s" time)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -134,17 +134,17 @@ If nil it is disabled.  Possible values for list-type are:
   :group 'dashboard)
 
 (defcustom dashboard-agenda-item-icon
-  (cond
-   ((eq dashboard-icon-type 'all-the-icons) (all-the-icons-octicon "primitive-dot" :height 1.0 :v-adjust 0.01))
-   ((eq dashboard-icon-type 'nerd-icons) (nerd-icons-octicon "nf-oct-primitive_dot" :height 1.0 :v-adjust 0.01)))
+  (pcase dashboard-icon-type
+   ('all-the-icons (all-the-icons-octicon "primitive-dot" :height 1.0 :v-adjust 0.01))
+   ('nerd-icons (nerd-icons-octicon "nf-oct-primitive_dot" :height 1.0 :v-adjust 0.01)))
   "Agenda item icon."
   :type 'string
   :group 'dashboard)
 
 (defcustom dashboard-remote-path-icon
-  (cond
-   ((eq dashboard-icon-type 'all-the-icons) (all-the-icons-octicon "radio-tower" :height 1.0 :v-adjust 0.01))
-   ((eq dashboard-icon-type 'nerd-icons) (nerd-icons-octicon "nf-oct-radio_tower" :height 1.0 :v-adjust 0.01)))
+  (pcase dashboard-icon-type
+   ('all-the-icons (all-the-icons-octicon "radio-tower" :height 1.0 :v-adjust 0.01))
+   ('nerd-icons (nerd-icons-octicon "nf-oct-radio_tower" :height 1.0 :v-adjust 0.01)))
   "Remote path icon."
   :type 'string
   :group 'dashboard)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -34,6 +34,7 @@
 (declare-function nerd-icons-icon-for-dir "ext:nerd-icons.el")
 (declare-function nerd-icons-icon-for-file "ext:nerd-icons.el")
 (declare-function nerd-icons-sucicon "ext:nerd-icons.el")
+(declare-function nerd-icons-octicon "ext:nerd-icons.el")
 (declare-function bookmark-get-filename "ext:bookmark.el")
 (declare-function bookmark-all-names "ext:bookmark.el")
 (declare-function calendar-date-compare "ext:calendar.el")

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -815,9 +815,9 @@ to widget creation."
                            (cond
                             ((or (string-equal ,section-name "Agenda for today:")
                                  (string-equal ,section-name "Agenda for the coming week:"))
-                             (dashboard--agenda-item-icon))
+                             dashboard--agenda-item-icon)
                             ((file-remote-p path)
-                             (dashboard--remote-path-icon))
+                             dashboard--remote-path-icon)
                             (t (dashboard-icon-for-file (file-name-nondirectory path)
                                                         :v-adjust -0.05))))))
               (setq tag (concat icon " " ,@rest))))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -31,6 +31,9 @@
 (declare-function all-the-icons-icon-for-file "ext:all-the-icons.el")
 (declare-function all-the-icons-fileicon "ext:data-fileicons.el")
 (declare-function all-the-icons-octicon "ext:data-octicons.el")
+(declare-function nerd-icons-icon-for-dir "ext:nerd-icons.el")
+(declare-function nerd-icons-icon-for-file "ext:nerd-icons.el")
+(declare-function nerd-icons-sucicon "ext:nerd-icons.el")
 (declare-function bookmark-get-filename "ext:bookmark.el")
 (declare-function bookmark-all-names "ext:bookmark.el")
 (declare-function calendar-date-compare "ext:calendar.el")
@@ -97,6 +100,53 @@ will be resized to the specified width in pixels, with aspect ratio
 preserved."
   :type 'integer
   :group 'dashboard)
+
+(defcustom dashboard-heading-icons
+  '((recents   . "history")
+    (bookmarks . "bookmark")
+    (agenda    . "calendar")
+    (projects  . "rocket")
+    (registers . "database"))
+
+  "Association list for the icons of the heading sections.
+Will be of the form `(list-type . icon-name-string)`.
+If nil it is disabled.  Possible values for list-type are:
+`recents' `bookmarks' `projects' `agenda' `registers'"
+  :type  '(repeat (alist :key-type symbol :value-type string))
+  :group 'dashboard)
+
+(defvar dashboard--agenda-item-icon nil)
+(defvar dashboard--remote-path-icon nil)
+(defcustom dashboard-icon-type 'all-the-icons
+  "Icon type used for dashboard.
+The value can be one of: `all-the-icons', `nerd-icons'."
+  :type 'symbol
+  :group 'dashboard
+  :set
+  (lambda (k v)
+    (and (eq v 'all-the-icons) (not (require 'all-the-icons nil t)) (setq v nil))
+    (and (eq v 'nerd-icons) (not (require 'nerd-icons nil t)) (setq v nil))
+    (set k v)
+    (setq dashboard--agenda-item-icon
+          (pcase (symbol-value k)
+            ('all-the-icons (all-the-icons-octicon "primitive-dot" :height 1.0 :v-adjust 0.01))
+            ('nerd-icons (nerd-icons-octicon "nf-oct-primitive_dot" :height 1.0 :v-adjust 0.01))))
+    (setq dashboard--remote-path-icon
+          (pcase (symbol-value k)
+            ('all-the-icons (all-the-icons-octicon "radio-tower" :height 1.0 :v-adjust 0.01))
+            ('nerd-icons (nerd-icons-octicon "nf-oct-radio_tower" :height 1.0 :v-adjust 0.01))))
+    (setq dashboard-heading-icons
+          (pcase (symbol-value k)
+            ('all-the-icons   '((recents   . "history")
+                                (bookmarks . "bookmark")
+                                (agenda    . "calendar")
+                                (projects  . "rocket")
+                                (registers . "database")))
+            ('nerd-icons   '((recents   . "nf-oct-history")
+                             (bookmarks . "nf-oct-bookmark")
+                             (agenda    . "nf-oct-calendar")
+                             (projects  . "nf-oct-rocket")
+                             (registers . "nf-oct-database")))))))
 
 (defcustom dashboard-set-heading-icons nil
   "When non nil, heading sections will have icons."
@@ -213,14 +263,40 @@ predicate value."
       (funcall dashboard-display-icons-p)
     dashboard-display-icons-p))
 
+(defun dashboard-icon-for-dir (dir &rest args)
+  "Get the formatted icon for DIR.
+ARGS should be a plist containing `:height', `:v-adjust',
+or `:face' properties."
+  (cond ((eq dashboard-icon-type 'all-the-icons) (apply #'all-the-icons-icon-for-dir dir args))
+        ((eq dashboard-icon-type 'nerd-icons) (apply #'nerd-icons-icon-for-dir dir args))))
+
+(defun dashboard-icon-for-file (file &rest args)
+  "Get the formatted icon for FILE.
+ARGS should be a plist containing `:height', `:v-adjust',
+or `:face' properties."
+  (cond ((eq dashboard-icon-type 'all-the-icons) (apply #'all-the-icons-icon-for-file file args))
+        ((eq dashboard-icon-type 'nerd-icons) (apply #'nerd-icons-icon-for-file file args))))
+
+(defun dashboard-octicon (name &rest args)
+  "Get the formatted octicon.
+ARGS should be a plist containing `:height', `:v-adjust',
+or `:face' properties."
+  (cond ((eq dashboard-icon-type 'all-the-icons) (apply #'all-the-icons-octicon name args))
+        ((eq dashboard-icon-type 'nerd-icons) (apply #'nerd-icons-octicon name args))))
+
 (defcustom dashboard-footer-icon
-  (if (and (dashboard-display-icons-p)
-           (or (fboundp 'all-the-icons-fileicon)
-               (require 'all-the-icons nil 'noerror)))
-      (all-the-icons-fileicon "emacs"
-                              :height 1.1
-                              :v-adjust -0.05
-                              :face 'font-lock-keyword-face)
+  (if (dashboard-display-icons-p)
+      (cond
+       ((eq dashboard-icon-type 'all-the-icons)
+        (all-the-icons-fileicon "emacs"
+                                :height 1.1
+                                :v-adjust -0.05
+                                :face 'font-lock-keyword-face))
+       ((eq dashboard-icon-type 'nerd-icons)
+        (nerd-icons-sucicon "nf-custom-emacs"
+                            :height 1.1
+                            :v-adjust -0.05
+                            :face 'font-lock-keyword-face)))
     (propertize ">" 'face 'dashboard-footer))
   "Footer's icon."
   :type 'string
@@ -309,19 +385,6 @@ Set to nil for unbounded."
   :type  'integer
   :group 'dashboard)
 
-(defcustom dashboard-heading-icons
-  '((recents   . "history")
-    (bookmarks . "bookmark")
-    (agenda    . "calendar")
-    (projects  . "rocket")
-    (registers . "database"))
-  "Association list for the icons of the heading sections.
-Will be of the form `(list-type . icon-name-string)`.
-If nil it is disabled.  Possible values for list-type are:
-`recents' `bookmarks' `projects' `agenda' `registers'"
-  :type  '(repeat (alist :key-type symbol :value-type string))
-  :group 'dashboard)
-
 (defcustom dashboard-path-style nil
   "Style to display path."
   :type '(choice
@@ -384,11 +447,11 @@ If nil it is disabled.  Possible values for list-type are:
   :group 'dashboard)
 
 (define-obsolete-face-alias
- 'dashboard-text-banner-face 'dashboard-text-banner "1.2.6")
+  'dashboard-text-banner-face 'dashboard-text-banner "1.2.6")
 (define-obsolete-face-alias
- 'dashboard-banner-logo-title-face 'dashboard-banner-logo-title "1.2.6")
+  'dashboard-banner-logo-title-face 'dashboard-banner-logo-title "1.2.6")
 (define-obsolete-face-alias
- 'dashboard-heading-face 'dashboard-heading "1.2.6")
+  'dashboard-heading-face 'dashboard-heading "1.2.6")
 
 ;;
 ;; Util
@@ -478,28 +541,23 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 (defun dashboard-insert-heading (heading &optional shortcut icon)
   "Insert a widget HEADING in dashboard buffer, adding SHORTCUT, ICON if provided."
   (when (and (dashboard-display-icons-p) dashboard-set-heading-icons)
-    ;; Try loading `all-the-icons'
-    (unless (or (fboundp 'all-the-icons-octicon)
-                (require 'all-the-icons nil 'noerror))
-      (error "Package `all-the-icons' isn't installed"))
-
     (insert (cond
              ((string-equal heading "Recent Files:")
-              (all-the-icons-octicon (cdr (assoc 'recents dashboard-heading-icons))
-                                     :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
+              (dashboard-octicon (cdr (assoc 'recents dashboard-heading-icons))
+                                 :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
              ((string-equal heading "Bookmarks:")
-              (all-the-icons-octicon (cdr (assoc 'bookmarks dashboard-heading-icons))
-                                     :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
+              (dashboard-octicon (cdr (assoc 'bookmarks dashboard-heading-icons))
+                                 :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
              ((or (string-equal heading "Agenda for today:")
                   (string-equal heading "Agenda for the coming week:"))
-              (all-the-icons-octicon (cdr (assoc 'agenda dashboard-heading-icons))
-                                     :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
+              (dashboard-octicon (cdr (assoc 'agenda dashboard-heading-icons))
+                                 :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
              ((string-equal heading "Registers:")
-              (all-the-icons-octicon (cdr (assoc 'registers dashboard-heading-icons))
-                                     :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
+              (dashboard-octicon (cdr (assoc 'registers dashboard-heading-icons))
+                                 :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
              ((string-equal heading "Projects:")
-              (all-the-icons-octicon (cdr (assoc 'projects dashboard-heading-icons))
-                                     :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
+              (dashboard-octicon (cdr (assoc 'projects dashboard-heading-icons))
+                                 :height 1.2 :v-adjust 0.0 :face 'dashboard-heading))
              ((not (null icon)) icon)
              (t " ")))
     (insert " "))
@@ -749,21 +807,19 @@ to widget creation."
           (insert "\n    ")
 
           (when (and (dashboard-display-icons-p)
-                     dashboard-set-file-icons
-                     (or (fboundp 'all-the-icons-icon-for-dir)
-                         (require 'all-the-icons nil 'noerror)))
+                     dashboard-set-file-icons)
             (let* ((path (car (last (split-string ,@rest " - "))))
                    (icon (if (and (not (file-remote-p path))
                                   (file-directory-p path))
-                             (all-the-icons-icon-for-dir path nil "")
+                             (dashboard-icon-for-dir path nil "")
                            (cond
                             ((or (string-equal ,section-name "Agenda for today:")
                                  (string-equal ,section-name "Agenda for the coming week:"))
-                             (all-the-icons-octicon "primitive-dot" :height 1.0 :v-adjust 0.01))
+                             (dashboard--agenda-item-icon))
                             ((file-remote-p path)
-                             (all-the-icons-octicon "radio-tower" :height 1.0 :v-adjust 0.01))
-                            (t (all-the-icons-icon-for-file (file-name-nondirectory path)
-                                                            :v-adjust -0.05))))))
+                             (dashboard--remote-path-icon))
+                            (t (dashboard-icon-for-file (file-name-nondirectory path)
+                                                        :v-adjust -0.05))))))
               (setq tag (concat icon " " ,@rest))))
 
           (widget-create 'item


### PR DESCRIPTION
**demo**
(Ubuntu 20.04, Gnome Desktop, Alacritty terminal, FiraCode Nerd Fonts)
![image](https://user-images.githubusercontent.com/22017420/235754564-ab8edc83-ce46-4558-9bdd-8886c33051b3.png)

**Major Changes**
I added `dashboard-icon-type` which specifies which icon package to use (either `'all-the-icons` or `'nerd-icons`). Based on `dashboard-icon-type`, other icon related custom variables such as `dashboard-heading-icons` will have corresponding default values. 

**Configuration for using Nerd Icons**
```elisp
(setq dashboard-display-icons-p t) ;; to use icons under terminal
(setq dashboard-icon-type 'nerd-icons)
```

**Things I am not sure about**
I'm not sure if my implementation for setting default values for some custom variables based on `dashboard-icon-type` is good. Let's say I set `dashboard-icon-type` to `'nerd-icons`. My current implementation for setting the default value of `dashboard-heading-icons` is to use a `pcase` statement. Does setting `dashboard-icon-type` trigger the evaluation of `dashboard-heading-icons`'s `pcase`? If I want to set a new value for `dashboard-heading-icons` in a init file, does it require some kind of ordering like I must setting `dashboard-icon-type` before setting `dashboard-heading-icons`?

**Other comments**
I have been using this dashboard for a few weeks now, and no issues so far. However, it might still have bugs that I did not think of. I'll be tracking nerd icons related issues here in emacs-dashboard, and I will try my best to solve them :)