### PR TITLE
dashboard-setup-startup-hook: add named functions to hooks

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -462,24 +462,21 @@ Optional argument ARGS adviced function arguments."
       (with-selected-window space-win
         (dashboard-insert-startupify-lists)))))
 
+(defun dashboard-initialize ()
+  "Switch to dashboard and run `dashboard-after-initialize-hook'."
+  (switch-to-buffer dashboard-buffer-name)
+  (goto-char (point-min))
+  (redisplay)
+  (run-hooks 'dashboard-after-initialize-hook))
+
 ;;;###autoload
 (defun dashboard-setup-startup-hook ()
-  "Setup post initialization hooks.
-If a command line argument is provided, assume a filename and skip displaying
-Dashboard."
-  (when (< (length command-line-args) 2)
-    (add-hook 'window-setup-hook (lambda ()
-                                   ;; 100 means `dashboard-resize-on-hook' will run last
-                                   (add-hook 'window-size-change-functions 'dashboard-resize-on-hook 100)
-                                   (dashboard-resize-on-hook)))
-    (add-hook 'after-init-hook (lambda ()
-                                 ;; Display useful lists of items
-                                 (dashboard-insert-startupify-lists)))
-    (add-hook 'emacs-startup-hook (lambda ()
-                                    (switch-to-buffer dashboard-buffer-name)
-                                    (goto-char (point-min))
-                                    (redisplay)
-                                    (run-hooks 'dashboard-after-initialize-hook)))))
+  "Setup post initialization hooks unless a command line argument is provided."
+  (when (< (length command-line-args) 2) ;; Assume no file name passed
+    (add-hook 'window-size-change-functions #'dashboard-resize-on-hook 100)
+    (add-hook 'window-setup-hook #'dashboard-resize-on-hook)
+    (add-hook 'after-init-hook #'dashboard-insert-startupify-lists)
+    (add-hook 'emacs-startup-hook #'dashboard-initialize)))
 
 (provide 'dashboard)
 ;;; dashboard.el ends here


### PR DESCRIPTION
dashboard-initialize: Replaces lambda added to emacs-startup-hook.
See: #474