### PR TITLE
Add xbm support for dashboard-startup-banner

### DIFF
--- a/README.org
+++ b/README.org
@@ -99,7 +99,7 @@ To update the banner or banner title
 ;; - 'official which displays the official emacs logo
 ;; - 'logo which displays an alternative emacs logo
 ;; - 1, 2 or 3 which displays one of the text banners
-;; - "path/to/your/image.gif", "path/to/your/image.png" or "path/to/your/text.txt" which displays whatever gif/image/text you would prefer
+;; - "path/to/your/image.gif", "path/to/your/image.png", "path/to/your/text.txt" or "path/to/your/image.xbm" which displays whatever gif/image/text/xbm you would prefer
 ;; - a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
 
 ;; Content is not centered by default. To center, set

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -697,6 +697,12 @@ String -> bool.
 Argument IMAGE-PATH path to the image."
   (eq 'gif (image-type image-path)))
 
+(defun dashboard--type-is-xbm-p (image-path)
+  "Return if image is a xbm.
+String -> bool.
+Argument IMAGE-PATH path to the image."
+  (eq 'xbm (image-type image-path)))
+
 (defun dashboard-insert-banner ()
   "Insert the banner at the top of the dashboard."
   (goto-char (point-max))
@@ -729,6 +735,8 @@ Argument IMAGE-PATH path to the image."
                          (list :max-height dashboard-image-banner-max-height)))))
           (setq image-spec
                 (cond ((dashboard--type-is-gif-p img)
+                       (create-image img))
+                      ((dashboard--type-is-xbm-p img)
                        (create-image img))
                       ((image-type-available-p 'imagemagick)
                        (apply 'create-image img 'imagemagick nil size-props))


### PR DESCRIPTION
Add option for image banner, xbm file from: https://github.com/meritamen/.emacs.d/blob/master/banners/evil.xbm
```
(dashboard-startup-banner (expand-file-name "banners/evil.xbm" user-emacs-directory)
```
<img width="672" alt="Screen Shot 2023-12-01 at 5 10 40 PM" src="https://github.com/emacs-dashboard/emacs-dashboard/assets/136421664/1630f8f4-203f-491d-9370-2232a909f07a">
