### PR TITLE
Add customization option to hide the cursor on the dashboard

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -91,12 +91,19 @@
   (when (featurep 'display-line-numbers) (display-line-numbers-mode -1))
   (when (featurep 'page-break-lines) (page-break-lines-mode 1))
   (setq-local revert-buffer-function #'dashboard-refresh-buffer)
+  (when dashboard-hide-cursor
+    (setq-local cursor-type nil))
   (setq inhibit-startup-screen t
         buffer-read-only t
         truncate-lines t))
 
 (defcustom dashboard-center-content nil
   "Whether to center content within the window."
+  :type 'boolean
+  :group 'dashboard)
+
+(defcustom dashboard-hide-cursor nil
+  "Whether to hide the cursor in the dashboard."
   :type 'boolean
   :group 'dashboard)
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -80,6 +80,11 @@
   :group 'dashboard
   :type 'hook)
 
+(defcustom dashboard-hide-cursor nil
+  "Whether to hide the cursor in the dashboard."
+  :type 'boolean
+  :group 'dashboard)
+
 (define-derived-mode dashboard-mode special-mode "Dashboard"
   "Dashboard major mode for startup screen."
   :group 'dashboard
@@ -99,11 +104,6 @@
 
 (defcustom dashboard-center-content nil
   "Whether to center content within the window."
-  :type 'boolean
-  :group 'dashboard)
-
-(defcustom dashboard-hide-cursor nil
-  "Whether to hide the cursor in the dashboard."
   :type 'boolean
   :group 'dashboard)
 


### PR DESCRIPTION
This PR adds an option to hide the cursor while in `dashboard-mode`. This is nice for users who disable all of the menu options.

Before:
<img width="1279" alt="Screenshot 2024-01-29 at 4 48 17 PM" src="https://github.com/emacs-dashboard/emacs-dashboard/assets/51159750/07554cdd-e5e2-4cf6-b69e-ff6655ea9c9e">

After:
<img width="1279" alt="Screenshot 2024-01-29 at 4 49 16 PM" src="https://github.com/emacs-dashboard/emacs-dashboard/assets/51159750/a424ba95-dca8-43c0-921a-63aba70c4eeb">
