### PR TITLE
Add option to vertically center dashboard

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -445,10 +445,12 @@ Optional argument ARGS adviced function arguments."
         (dashboard-insert-footer)
         (when dashboard-vertically-center-content
           (goto-char (point-min))
-          (let* ((buffer-lines (count-lines (point-min) (point-max)))
-                 (vertical-padding (floor (/ (- (window-height) buffer-lines) 2))))
-            (when (> vertical-padding 0)
-              (insert (make-string vertical-padding ?\n)))))
+          (when-let* ((content-height (cdr (window-absolute-pixel-position (point-max))))
+                      (vertical-padding (floor (/ (- (window-pixel-height) content-height) 2)))
+                      ((> vertical-padding 0))
+                      (vertical-lines (/ vertical-padding
+                                         (line-pixel-height))))
+            (insert (make-string vertical-lines ?\n))))
         (goto-char (point-min))
         (dashboard-mode)))
     (when recentf-is-on

--- a/dashboard.el
+++ b/dashboard.el
@@ -100,6 +100,11 @@
   :type 'boolean
   :group 'dashboard)
 
+(defcustom dashboard-vertically-center-content nil
+  "Whether to vertically center content within the window."
+  :type 'boolean
+  :group 'dashboard)
+
 (defconst dashboard-buffer-name "*dashboard*"
   "Dashboard's buffer name.")
 
@@ -438,6 +443,12 @@ Optional argument ARGS adviced function arguments."
           (delete-char -1)
           (insert dashboard-page-separator))
         (dashboard-insert-footer)
+        (when dashboard-vertically-center-content
+          (goto-char (point-min))
+          (let* ((buffer-lines (count-lines (point-min) (point-max)))
+                 (vertical-padding (floor (/ (- (window-height) buffer-lines) 2))))
+            (when (> vertical-padding 0)
+              (insert (make-string vertical-padding ?\n)))))
         (goto-char (point-min))
         (dashboard-mode)))
     (when recentf-is-on


### PR DESCRIPTION
This PR adds an option to vertically center the dashboard content. I tested it with a few different dashboard configurations on MacOS and everything seems to be working.

Before:
<img width="1279" alt="Screenshot 2024-01-29 at 4 54 07 PM" src="https://github.com/emacs-dashboard/emacs-dashboard/assets/51159750/a5dd9989-ed25-4536-b47f-6336c01792af">


After:
<img width="1279" alt="Screenshot 2024-01-29 at 4 54 23 PM" src="https://github.com/emacs-dashboard/emacs-dashboard/assets/51159750/19d50d07-f1d5-4a65-b237-4a4b06f08326">

