### PR TITLE
Support for insert startupify list in order, support for solaire mode and more.

### DIFF
--- a/README.org
+++ b/README.org
@@ -94,13 +94,17 @@ To update the banner or banner title
   (setq dashboard-banner-logo-title "Welcome to Emacs Dashboard")
   ;; Set the banner
   (setq dashboard-startup-banner [VALUE])
-  ;; Value can be
-  ;; - nil to display no banner
-  ;; - 'official which displays the official emacs logo
-  ;; - 'logo which displays an alternative emacs logo
-  ;; - 1, 2 or 3 which displays one of the text banners
-  ;; - "path/to/your/image.gif", "path/to/your/image.png", "path/to/your/text.txt" or "path/to/your/image.xbm" which displays whatever gif/image/text/xbm you would prefer
-  ;; - a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
+  ;; Value can be:
+  ;;   - nil to display no banner.
+  ;;   - 'official which displays the official emacs logo.
+  ;;   - 'logo which displays an alternative emacs logo.
+  ;;   - an integer which displays one of the text banners
+  ;;     (see dashboard-banners-directory files).
+  ;;   - a string that specifies a path for a custom banner
+  ;;     currently supported types are gif/image/text/xbm.
+  ;;   - a cons of 2 strings which specifies the path of an image to use
+  ;;     and other path of a text file to use if image isn't supported.
+  ;;     ("path/to/image/file/image.png" . "path/to/text/file/text.txt").
 
   ;; Content is not centered by default. To center, set
   (setq dashboard-center-content t)
@@ -111,7 +115,7 @@ To update the banner or banner title
   (setq dashboard-show-shortcuts nil)
 #+END_SRC
 
-To customize which widgets are displayed, you can use the following snippet
+To customize which items are displayed, you can use the following snippet
 #+BEGIN_SRC elisp
 (setq dashboard-items '((recents   . 5)
                         (bookmarks . 5)
@@ -120,6 +124,23 @@ To customize which widgets are displayed, you can use the following snippet
                         (registers . 5)))
  #+END_SRC
 This will add the recent files, bookmarks, projects, org-agenda and registers widgets to your dashboard each displaying 5 items.
+
+To customize which widgets to display in order (example: Banner, footer message ...):
+#+begin_src emacs-lisp
+  (setq dashboard-startupify-list '(dashboard-insert-banner
+                                    dashboard-insert-banner-title
+                                    dashboard-insert-init-info
+                                    dashboard-insert-newline
+                                    dashboard-insert-footer
+                                    dashboard-insert-items
+                                    dashboard-insert-navigator
+                                    dashboard-insert-newline))
+#+end_src
+
+To customize string format in shortcuts:
+#+begin_src emacs-lisp
+  (setq dashboard-heading-shorcut-format " [%s]")
+#+end_src
 
 To customize item shortcuts:
 #+BEGIN_SRC elisp
@@ -134,7 +155,7 @@ To modify the widget heading name:
 #+BEGIN_SRC elisp
   (setq dashboard-item-names '(("Recent Files:"               . "Recently opened files:")
                                ("Agenda for today:"           . "Today's agenda:")
-                               ("Agenda for the coming week:" . "Agenda:"))
+                               ("Agenda for the coming week:" . "Agenda:")))
 #+END_SRC
 
 The default length for each item.
@@ -240,6 +261,16 @@ To customize it and customize its icon;
                                                    :v-adjust -0.05
                                                    :face 'font-lock-keyword-face))
 #+END_SRC
+
+To use it with [[https://github.com/hlissner/emacs-solaire-mode][solaire-mode]]:
+#+begin_src emacs-lisp
+(add-hook 'dashboard-after-initialize-hook #'solaire-mode)
+#+end_src
+
+Or for use-package users
+#+begin_src emacs-lisp
+:hook (dashboard-after-initialize . solaire-mode)
+#+end_src
 
 To use it with [[https://github.com/ericdanan/counsel-projectile][counsel-projectile]] or [[https://github.com/bbatsov/persp-projectile][persp-projectile]]
 

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -601,9 +601,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 
 (defun dashboard-insert-newline (&optional n)
   "Insert N times of newlines."
-  (unless n
-    (setq n 1))
-  (dotimes (_ 1)
+  (dotimes (_ (or n 1))
     (insert "\n")))
 
 (defun dashboard-insert-heading (heading &optional shortcut icon)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -382,10 +382,7 @@ Possible values for list-type are: `recents', `bookmarks', `projects',
   :type  '(alist :key-type symbol :value-type function)
   :group 'dashboard)
 
-(defcustom dashboard-projects-backend
-  (if (fboundp 'projectile-find-file)
-      'projectile
-    'project-el)
+(defcustom dashboard-projects-backend 'project-el
   "The package that supplies the list of recent projects.
 With the value `projectile', the projects widget uses the package
 projectile (available in MELPA).  With the value `project-el',
@@ -815,8 +812,7 @@ Argument IMAGE-PATH path to the image."
     (let ((init-info (if (functionp dashboard-init-info)
                          (funcall dashboard-init-info)
                        dashboard-init-info)))
-      (dashboard-insert-center (propertize init-info 'face 'font-lock-comment-face))
-      (insert "\n"))))
+      (dashboard-insert-center (propertize init-info 'face 'font-lock-comment-face)))))
 
 (defun dashboard-insert-navigator ()
   "Insert Navigator of the dashboard."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -80,7 +80,11 @@
 
 (defcustom dashboard-page-separator "\n\n"
   "Separator to use between the different pages."
-  :type 'string
+  :type '(choice
+          (const :tag "Default" "\n\n")
+          (const :tag "Use Page indicator (requires page-break-lines)"
+                 "\n\f\n")
+          (string :tag "Use Custom String"))
   :group 'dashboard)
 
 (defcustom dashboard-image-banner-max-height 0
@@ -594,6 +598,13 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 (defun dashboard-insert-page-break ()
   "Insert a page break line in dashboard buffer."
   (dashboard-append dashboard-page-separator))
+
+(defun dashboard-insert-newline (&optional n)
+  "Insert N times of newlines."
+  (unless n
+    (setq n 1))
+  (dotimes (_ 1)
+    (insert "\n")))
 
 (defun dashboard-insert-heading (heading &optional shortcut icon)
   "Insert a widget HEADING in dashboard buffer, adding SHORTCUT, ICON if provided."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -595,7 +595,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   "Insert a page break line in dashboard buffer."
   (dashboard-append dashboard-page-separator))
 
-(defun dashboard-insert-heading (heading &optional shortcut shortcut icon)
+(defun dashboard-insert-heading (heading &optional shortcut icon)
   "Insert a widget HEADING in dashboard buffer, adding SHORTCUT, ICON if provided."
   (when (and (dashboard-display-icons-p) dashboard-set-heading-icons)
     (let ((args `( :height   ,dashboard-heading-icon-height

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -798,8 +798,11 @@ Argument IMAGE-PATH path to the image."
                     (t nil)))
                   (prefix (propertize " " 'display prop)))
         (add-text-properties start (point) `(line-prefix ,prefix wrap-prefix ,prefix)))
-      (insert "\n\n")
-      (add-text-properties start (point) '(cursor-intangible t inhibit-isearch t))))
+      (insert "\n")
+      (add-text-properties start (point) '(cursor-intangible t inhibit-isearch t)))))
+
+(defun dashboard-insert-banner-title ()
+  "Insert `dashboard-banner-logo-title' if it's non-nil."
   (when dashboard-banner-logo-title
     (dashboard-insert-center (propertize dashboard-banner-logo-title 'face 'dashboard-banner-logo-title))
     (insert "\n")))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -342,7 +342,7 @@ ARGS should be a plist containing `:height', `:v-adjust', or `:face' properties.
   :type 'string
   :group 'dashboard)
 
-(defcustom dashboard-heading-shorcut-key-str " (%s)"
+(defcustom dashboard-heading-shorcut-format " (%s)"
   "String for display key used in headings."
   :type 'string
   :group 'dashboard)
@@ -633,7 +633,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   (let ((ov (make-overlay (- (point) (length heading)) (point) nil t)))
     (overlay-put ov 'display (or (cdr (assoc heading dashboard-item-names)) heading))
     (overlay-put ov 'face 'dashboard-heading))
-  (when shortcut (insert (format dashboard-heading-shorcut-key-str shortcut))))
+  (when shortcut (insert (format dashboard-heading-shorcut-format shortcut))))
 
 (defun dashboard-center-text (start end)
   "Center the text between START and END."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -922,7 +922,6 @@ to widget creation."
   "Insert footer of dashboard."
   (when-let ((footer (and dashboard-set-footer (dashboard-random-footer)))
              (footer-icon (dashboard-replace-displayable dashboard-footer-icon)))
-    (insert "\n")
     (dashboard-insert-center
      (if (string-empty-p footer-icon) footer-icon
        (concat footer-icon " "))

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -342,6 +342,11 @@ ARGS should be a plist containing `:height', `:v-adjust', or `:face' properties.
   :type 'string
   :group 'dashboard)
 
+(defcustom dashboard-heading-shorcut-key-str " (%s)"
+  "String for display key used in headings."
+  :type 'string
+  :group 'dashboard)
+
 (defcustom dashboard-startup-banner 'official
   "Specify the startup banner.
 Default value is `official', it displays the Emacs logo.  `logo' displays Emacs
@@ -590,7 +595,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   "Insert a page break line in dashboard buffer."
   (dashboard-append dashboard-page-separator))
 
-(defun dashboard-insert-heading (heading &optional shortcut icon)
+(defun dashboard-insert-heading (heading &optional shortcut shortcut icon)
   "Insert a widget HEADING in dashboard buffer, adding SHORTCUT, ICON if provided."
   (when (and (dashboard-display-icons-p) dashboard-set-heading-icons)
     (let ((args `( :height   ,dashboard-heading-icon-height
@@ -628,7 +633,7 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   (let ((ov (make-overlay (- (point) (length heading)) (point) nil t)))
     (overlay-put ov 'display (or (cdr (assoc heading dashboard-item-names)) heading))
     (overlay-put ov 'face 'dashboard-heading))
-  (when shortcut (insert (format " (%s)" shortcut))))
+  (when shortcut (insert (format dashboard-heading-shorcut-key-str shortcut))))
 
 (defun dashboard-center-text (start end)
   "Center the text between START and END."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -370,10 +370,13 @@ nil then no banner is displayed."
 Will be of the form `(list-type . list-function)'.
 Possible values for list-type are: `recents', `bookmarks', `projects',
 `agenda' ,`registers'."
-  :type  '(repeat (alist :key-type symbol :value-type function))
+  :type  '(alist :key-type symbol :value-type function)
   :group 'dashboard)
 
-(defcustom dashboard-projects-backend 'projectile
+(defcustom dashboard-projects-backend
+  (if (fboundp 'projectile-find-file)
+      'projectile
+    'project-el)
   "The package that supplies the list of recent projects.
 With the value `projectile', the projects widget uses the package
 projectile (available in MELPA).  With the value `project-el',
@@ -785,9 +788,7 @@ Argument IMAGE-PATH path to the image."
       (add-text-properties start (point) '(cursor-intangible t inhibit-isearch t))))
   (when dashboard-banner-logo-title
     (dashboard-insert-center (propertize dashboard-banner-logo-title 'face 'dashboard-banner-logo-title))
-    (insert "\n\n"))
-  (dashboard-insert-navigator)
-  (dashboard-insert-init-info))
+    (insert "\n")))
 
 ;;
 ;;; Initialize info
@@ -834,8 +835,7 @@ Argument IMAGE-PATH path to the image."
                          :format "%[%t%]")
           (insert " ")))
       (dashboard-center-text (line-beginning-position) (line-end-position))
-      (insert "\n"))
-    (insert "\n")))
+      (insert "\n"))))
 
 (defmacro dashboard-insert-section (section-name list list-size shortcut-id shortcut-char action &rest widget-params)
   "Add a section with SECTION-NAME and LIST of LIST-SIZE items to the dashboard.

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -809,14 +809,14 @@ Argument IMAGE-PATH path to the image."
 
 ;;
 ;;; Initialize info
-
 (defun dashboard-insert-init-info ()
   "Insert init info when `dashboard-set-init-info' is t."
   (when dashboard-set-init-info
     (let ((init-info (if (functionp dashboard-init-info)
                          (funcall dashboard-init-info)
                        dashboard-init-info)))
-      (dashboard-insert-center (propertize init-info 'face 'font-lock-comment-face)))))
+      (dashboard-insert-center (propertize init-info 'face 'font-lock-comment-face))
+      (insert "\n"))))
 
 (defun dashboard-insert-navigator ()
   "Insert Navigator of the dashboard."

--- a/dashboard.el
+++ b/dashboard.el
@@ -120,10 +120,14 @@
 
 (defcustom dashboard-startupify-list
   '((banner    . dashboard-insert-banner)
-    (items     . dashboard-insert-items)
+    (new-line . (lambda () (insert "\n")))
     (navigator . dashboard-insert-navigator)
+    (items     . dashboard-insert-items)
+    (new-line . (lambda () (insert "\n")))
+    (footer . dashboard-insert-footer)
+    (new-line . (lambda () (insert "\n")))
     (init-info . dashboard-insert-init-info))
-  "List for insert dashboard widgets in order."
+  "List of dashboard widgets (in order) to insert in dashboard buffer."
   :type '(alist :key-type symbol :value-type function)
   :group 'dashboard)
 
@@ -433,14 +437,16 @@ See `dashboard-item-generators' for all items available."
               (push (point) dashboard--section-starts)
               (funcall item-generator list-size)
               (goto-char (point-max))
-              ;; add a newline so the next section-name doesn't get include
-              ;; on the same line.
-              (insert "\n")
+              
               (when recentf-is-on
                 (setq recentf-list origial-recentf-list))
               (setq max-line-length
                     (max max-line-length (dashboard-maximum-section-length)))))
           dashboard-items)
+    
+    ;; add a newline so the next section-name doesn't get include
+    ;; on the same line.
+    (insert "\n")
     (when dashboard-center-content
       (dashboard-center-text
        (if dashboard--section-starts

--- a/dashboard.el
+++ b/dashboard.el
@@ -129,7 +129,6 @@
     dashboard-insert-newline
     dashboard-insert-init-info
     dashboard-insert-items
-    dashboard-insert-newline
     dashboard-insert-footer)
   "List of dashboard widgets (in order) to insert in dashboard buffer."
   :type '(repeat function)
@@ -447,16 +446,14 @@ See `dashboard-item-generators' for all items available."
               (setq max-line-length
                     (max max-line-length (dashboard-maximum-section-length)))))
           dashboard-items)
-    
-    ;; add a newline so the next section-name doesn't get include
-    ;; on the same line.
-    (insert "\n")
+
     (when dashboard-center-content
       (dashboard-center-text
        (if dashboard--section-starts
            (car (last dashboard--section-starts))
          (point))
-       (point-max)))))
+       (point-max)))
+    (dashboard-insert-page-break)))
 
 (defun dashboard-insert-startupify-lists ()
   "Insert the list of widgets into the buffer."

--- a/dashboard.el
+++ b/dashboard.el
@@ -120,6 +120,7 @@
 
 (defcustom dashboard-startupify-list
   '(dashboard-insert-banner
+    dashboard-insert-newline
     dashboard-insert-banner-title
     dashboard-insert-newline
     dashboard-insert-navigator

--- a/dashboard.el
+++ b/dashboard.el
@@ -118,10 +118,6 @@
   :type 'boolean
   :group 'dashboard)
 
-(defcustom dashboard-use-solaire t
-  "Whether to use 'solaire-mode' (if installed) in dashboard."
-  :type 'boolean)
-
 (defcustom dashboard-startupify-list
   '(dashboard-insert-banner
     dashboard-insert-newline
@@ -466,11 +462,7 @@ See `dashboard-item-generators' for all items available."
     (when recentf-is-on
       (setq recentf-list (dashboard-subseq recentf-list dashboard-num-recents)))
     (dashboard--with-buffer
-     (if (fboundp 'solaire-mode)
-         (if dashboard-use-solaire
-             (solaire-mode t)
-           (solaire-mode -1)))
-      (when (or dashboard-force-refresh (not (eq major-mode 'dashboard-mode)))
+     (when (or dashboard-force-refresh (not (eq major-mode 'dashboard-mode)))
         (erase-buffer)
         (setq dashboard--section-starts nil)
         

--- a/dashboard.el
+++ b/dashboard.el
@@ -465,7 +465,7 @@ See `dashboard-item-generators' for all items available."
       (when (or dashboard-force-refresh (not (eq major-mode 'dashboard-mode)))
         (erase-buffer)
         (setq dashboard--section-starts nil)
-        
+
         (mapc (lambda (fn)
                 (funcall fn))
               dashboard-startupify-list)
@@ -486,7 +486,7 @@ See `dashboard-item-generators' for all items available."
         (goto-char (point-min))
         (dashboard-mode)))
     (when recentf-is-on
-      (setq recentf-list origial-recentf-list)))))
+      (setq recentf-list origial-recentf-list))))
 
 ;;;###autoload
 (defun dashboard-open (&rest _)

--- a/dashboard.el
+++ b/dashboard.el
@@ -118,6 +118,15 @@
   :type 'boolean
   :group 'dashboard)
 
+(defcustom dashboard-startupify-list
+  '((banner    . dashboard-insert-banner)
+    (items     . dashboard-insert-items)
+    (navigator . dashboard-insert-navigator)
+    (init-info . dashboard-insert-init-info))
+  "List for insert dashboard widgets in order."
+  :type '(alist :key-type symbol :value-type function)
+  :group 'dashboard)
+
 (defconst dashboard-buffer-name "*dashboard*"
   "Dashboard's buffer name.")
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -128,7 +128,8 @@
     dashboard-insert-navigator
     dashboard-insert-newline
     dashboard-insert-init-info
-    dashboard-insert-items
+    dashboard-insert-items 
+    dashboard-insert-newline
     dashboard-insert-footer)
   "List of dashboard widgets (in order) to insert in dashboard buffer."
   :type '(repeat function)

--- a/dashboard.el
+++ b/dashboard.el
@@ -118,17 +118,21 @@
   :type 'boolean
   :group 'dashboard)
 
+(defucustom dashboard-use-solaire t
+  "Whether to use 'solaire-mode' (if installed) in dashboard."
+  :type 'boolean)
+
 (defcustom dashboard-startupify-list
-  '((banner    . dashboard-insert-banner)
-    (new-line . (lambda () (insert "\n")))
-    (navigator . dashboard-insert-navigator)
-    (items     . dashboard-insert-items)
-    (new-line . (lambda () (insert "\n")))
-    (footer . dashboard-insert-footer)
-    (new-line . (lambda () (insert "\n")))
-    (init-info . dashboard-insert-init-info))
+  '(dashboard-insert-banner
+    dashboard-insert-newline
+    dashboard-insert-navigator
+    dashboard-insert-newline
+    dashboard-insert-init-info
+    dashboard-insert-items
+    dashboard-insert-newline
+    dashboard-insert-footer)
   "List of dashboard widgets (in order) to insert in dashboard buffer."
-  :type '(alist :key-type symbol :value-type function)
+  :type '(repeat function)
   :group 'dashboard)
 
 (defconst dashboard-buffer-name "*dashboard*"
@@ -460,13 +464,14 @@ See `dashboard-item-generators' for all items available."
   (let ((inhibit-redisplay t)
         (recentf-is-on (recentf-enabled-p))
         (origial-recentf-list recentf-list)
-        (dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0))
-        (max-line-length 0))
+        (dashboard-num-recents (or (cdr (assoc 'recents dashboard-items)) 0)))
     (when recentf-is-on
       (setq recentf-list (dashboard-subseq recentf-list dashboard-num-recents)))
     (dashboard--with-buffer
      (if (fboundp 'solaire-mode)
-          (solaire-mode t))
+         (if dashboard-use-solaire
+             (solaire-mode t)
+           (solaire-mode -1)))
       (when (or dashboard-force-refresh (not (eq major-mode 'dashboard-mode)))
         (erase-buffer)
         (setq dashboard--section-starts nil)

--- a/dashboard.el
+++ b/dashboard.el
@@ -120,6 +120,7 @@
 
 (defcustom dashboard-startupify-list
   '(dashboard-insert-banner
+    dashboard-insert-banner-title
     dashboard-insert-newline
     dashboard-insert-navigator
     dashboard-insert-newline

--- a/dashboard.el
+++ b/dashboard.el
@@ -118,7 +118,7 @@
   :type 'boolean
   :group 'dashboard)
 
-(defucustom dashboard-use-solaire t
+(defcustom dashboard-use-solaire t
   "Whether to use 'solaire-mode' (if installed) in dashboard."
   :type 'boolean)
 
@@ -476,10 +476,8 @@ See `dashboard-item-generators' for all items available."
         (erase-buffer)
         (setq dashboard--section-starts nil)
         
-        (mapc (lambda (alist)
-                (let* ((name (or (car-safe alist) alist))
-                       (fn (cdr-safe (assoc name dashboard-startupify-list))))
-                  (funcall fn)))
+        (mapc (lambda (fn)
+                (funcall fn)
               dashboard-startupify-list)
 
         (save-excursion

--- a/dashboard.el
+++ b/dashboard.el
@@ -124,7 +124,7 @@
     dashboard-insert-navigator
     dashboard-insert-newline
     dashboard-insert-init-info
-    dashboard-insert-items 
+    dashboard-insert-items
     dashboard-insert-newline
     dashboard-insert-footer)
   "List of dashboard widgets (in order) to insert in dashboard buffer."
@@ -437,7 +437,7 @@ See `dashboard-item-generators' for all items available."
               (push (point) dashboard--section-starts)
               (funcall item-generator list-size)
               (goto-char (point-max))
-              
+
               (when recentf-is-on
                 (setq recentf-list origial-recentf-list))
               (setq max-line-length

--- a/dashboard.el
+++ b/dashboard.el
@@ -462,12 +462,12 @@ See `dashboard-item-generators' for all items available."
     (when recentf-is-on
       (setq recentf-list (dashboard-subseq recentf-list dashboard-num-recents)))
     (dashboard--with-buffer
-     (when (or dashboard-force-refresh (not (eq major-mode 'dashboard-mode)))
+      (when (or dashboard-force-refresh (not (eq major-mode 'dashboard-mode)))
         (erase-buffer)
         (setq dashboard--section-starts nil)
         
         (mapc (lambda (fn)
-                (funcall fn)
+                (funcall fn))
               dashboard-startupify-list)
 
         (save-excursion
@@ -486,7 +486,7 @@ See `dashboard-item-generators' for all items available."
         (goto-char (point-min))
         (dashboard-mode)))
     (when recentf-is-on
-      (setq recentf-list origial-recentf-list))))
+      (setq recentf-list origial-recentf-list)))))
 
 ;;;###autoload
 (defun dashboard-open (&rest _)


### PR DESCRIPTION
Hello,
I made this patch that include some
features to dashboard:

- Support for insert startupify list in order,
   this adds more customization to dashboard.
- Support for solaire-more.
- Bugs fix to some defcustom types.

I would like to hear your thought and reviews about this patch.
Thanks.