### PR TITLE
Deprecate unnecessary user options.

### DIFF
--- a/README.org
+++ b/README.org
@@ -95,7 +95,6 @@ To update the banner or banner title
   ;; Set the banner
   (setq dashboard-startup-banner [VALUE])
   ;; Value can be:
-  ;;   - nil to display no banner.
   ;;   - 'official which displays the official emacs logo.
   ;;   - 'logo which displays an alternative emacs logo.
   ;;   - an integer which displays one of the text banners
@@ -221,11 +220,6 @@ To modify heading icons with another icon from nerd-icons octicons:
                                     (bookmarks . "nf-oct-book")))
 #+END_SRC
 
-To show navigators below the banner:
-#+BEGIN_SRC emacs-lisp
-  (setq dashboard-set-navigator t)
-#+END_SRC
-
 To customize the buttons of the navigator like this:
 #+BEGIN_SRC emacs-lisp
   ;; Format: "(icon title help action face prefix suffix)"
@@ -245,23 +239,12 @@ To customize the buttons of the navigator like this:
            ("⚑" nil "Show flags" (lambda (&rest _) (message "flag")) error))))
 #+END_SRC
 
-To show info about the packages loaded and the init time:
-#+BEGIN_SRC elisp
-  (setq dashboard-set-init-info t)
-#+END_SRC
-
 Also, the message can be customized like this:
 #+BEGIN_SRC elisp
   (setq dashboard-init-info "This is an init message!")
 #+END_SRC
 
-A randomly selected footnote will be displayed. To disable it:
-#+BEGIN_SRC elisp
-  (setq dashboard-set-footer nil)
-#+END_SRC
-
 To customize it and customize its icon;
-
 #+BEGIN_SRC elisp
   (setq dashboard-footer-messages '("Dashboard is pretty cool!"))
   (setq dashboard-footer-icon (all-the-icons-octicon "dashboard"

--- a/README.org
+++ b/README.org
@@ -138,6 +138,7 @@ To customize which widgets to display in order (example: Banner, footer message 
                                     dashboard-insert-newline
                                     dashboard-insert-footer))
 #+end_src
+See dashboard-startupify-list for all the widgets avalaibles.
 
 To enable cycle navigation between each section:
 #+begin_src emacs-lisp

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -71,6 +71,15 @@
 (declare-function string-pixel-width "subr-x.el")   ; TODO: remove this after 29.1
 (declare-function shr-string-pixel-width "shr.el")  ; TODO: remove this after 29.1
 
+(make-obsolete-variable 'dashboard-set-navigator
+                        'dashboard-startupify-list "1.9.0")
+
+(make-obsolete-variable 'dashboard-set-init-info
+                        'dashboard-startupify-list "1.9.0")
+
+(make-obsolete-variable 'dashboard-set-footer
+                        'dashboard-startupify-list "1.9.0")
+
 (defvar recentf-list nil)
 
 (defvar dashboard-buffer-name)
@@ -122,21 +131,6 @@ See `create-image' and Info node `(elisp)Image Descriptors'."
 
 (defcustom dashboard-set-file-icons nil
   "When non nil, file lists will have icons."
-  :type 'boolean
-  :group 'dashboard)
-
-(defcustom dashboard-set-navigator nil
-  "When non nil, a navigator will be displayed under the banner."
-  :type 'boolean
-  :group 'dashboard)
-
-(defcustom dashboard-set-init-info t
-  "When non nil, init info will be displayed under the banner."
-  :type 'boolean
-  :group 'dashboard)
-
-(defcustom dashboard-set-footer t
-  "When non nil, a footer will be displayed at the bottom."
   :type 'boolean
   :group 'dashboard)
 
@@ -358,8 +352,7 @@ alternative logo.  If set to `ascii', the value of `dashboard-banner-ascii'
 will be used as the banner.  An integer value is the index of text banner.
 A string value must be a path to a .PNG or .TXT file.  If the value is
 nil then no banner is displayed."
-  :type '(choice (const   :tag "no banner" nil)
-                 (const   :tag "offical"   official)
+  :type '(choice (const   :tag "offical"   official)
                  (const   :tag "logo"      logo)
                  (const   :tag "ascii"     ascii)
                  (integer :tag "index of a text banner")
@@ -682,7 +675,6 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 (defun dashboard-choose-banner ()
   "Return a plist specifying the chosen banner based on `dashboard-startup-banner'."
   (pcase dashboard-startup-banner
-    ('nil nil)
     ('official
      (append (when (image-type-available-p 'png)
                (list :image dashboard-banner-official-png))
@@ -812,16 +804,15 @@ Argument IMAGE-PATH path to the image."
 ;;
 ;;; Initialize info
 (defun dashboard-insert-init-info ()
-  "Insert init info when `dashboard-set-init-info' is t."
-  (when dashboard-set-init-info
-    (let ((init-info (if (functionp dashboard-init-info)
+  "Insert init info."
+  (let ((init-info (if (functionp dashboard-init-info)
                          (funcall dashboard-init-info)
                        dashboard-init-info)))
-      (dashboard-insert-center (propertize init-info 'face 'font-lock-comment-face)))))
+      (dashboard-insert-center (propertize init-info 'face 'font-lock-comment-face))))
 
 (defun dashboard-insert-navigator ()
   "Insert Navigator of the dashboard."
-  (when (and dashboard-set-navigator dashboard-navigator-buttons)
+  (when dashboard-navigator-buttons
     (dolist (line dashboard-navigator-buttons)
       (dolist (btn line)
         (let* ((icon (car btn))
@@ -922,7 +913,7 @@ to widget creation."
 
 (defun dashboard-insert-footer ()
   "Insert footer of dashboard."
-  (when-let ((footer (and dashboard-set-footer (dashboard-random-footer)))
+  (when-let ((footer (dashboard-random-footer))
              (footer-icon (dashboard-replace-displayable dashboard-footer-icon)))
     (dashboard-insert-center
      (if (string-empty-p footer-icon) footer-icon

--- a/dashboard.el
+++ b/dashboard.el
@@ -123,13 +123,24 @@
     dashboard-insert-newline
     dashboard-insert-banner-title
     dashboard-insert-newline
-    dashboard-insert-navigator
-    dashboard-insert-newline
     dashboard-insert-init-info
     dashboard-insert-items
     dashboard-insert-newline
     dashboard-insert-footer)
-  "List of dashboard widgets (in order) to insert in dashboard buffer."
+    "List of dashboard widgets (in order) to insert in dashboard buffer.
+Avalaible functions:
+  `dashboard-insert-newline'
+  `dashboard-insert-page-break'
+  `dashboard-insert-banner'
+  `dashboard-insert-banner-title'
+  `dashboard-insert-navigator'
+  `dashboard-insert-init-info'
+  `dashboard-insert-items'
+  `dashboard-insert-footer'
+
+You can also add your custom function or a lambda to the list.
+example:
+ (lambda () (delete-char -1))"
   :type '(repeat function)
   :group 'dashboard)
 


### PR DESCRIPTION
As Explained here:
https://github.com/emacs-dashboard/emacs-dashboard/issues/508
User Options like: dashboard-set-footer, dashboard-set-navigator and dashboard-set-init-info
are unnecessary and can be replaced by dashboard-startupify-list, this patch do this job.