### PR TITLE
Add new hook for dashboard.

### DIFF
--- a/README.org
+++ b/README.org
@@ -257,7 +257,7 @@ To customize it and customize its icon;
 
 To use it with [[https://github.com/hlissner/emacs-solaire-mode][solaire-mode]]:
 #+begin_src emacs-lisp
-  (add-hook 'dashboard-after-initialize-hook #'solaire-mode)
+  (add-hook 'dashboard-before-initialize-hook #'solaire-mode)
 #+end_src
 
 Or for use-package users

--- a/README.org
+++ b/README.org
@@ -262,7 +262,7 @@ To use it with [[https://github.com/hlissner/emacs-solaire-mode][solaire-mode]]:
 
 Or for use-package users
 #+begin_src emacs-lisp
-  :hook (dashboard-after-initialize . solaire-mode)
+  :hook (dashboard-before-initialize . solaire-mode)
 #+end_src
 
 To use it with [[https://github.com/ericdanan/counsel-projectile][counsel-projectile]] or [[https://github.com/bbatsov/persp-projectile][persp-projectile]]

--- a/dashboard.el
+++ b/dashboard.el
@@ -81,13 +81,13 @@
     map)
   "Keymap for dashboard mode.")
 
-(defcustom dashboard-after-initialize-hook nil
-  "Hook that is run after dashboard buffer is initialized."
+(defcustom dashboard-before-initialize-hook nil
+  "Hook that is run before dashboard buffer is initialized."
   :group 'dashboard
   :type 'hook)
 
-(defcustom dashboard-before-initialize-hook nil
-  "Hook that is run before dashboard buffer is initialized."
+(defcustom dashboard-after-initialize-hook nil
+  "Hook that is run after dashboard buffer is initialized."
   :group 'dashboard
   :type 'hook)
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -445,7 +445,6 @@ Optional argument ARGS adviced function arguments."
   "Execute BODY in dashboard buffer."
   (declare (indent 0))
   `(with-current-buffer (get-buffer-create dashboard-buffer-name)
-     (run-hooks 'dashboard-before-initialize-hook)
      (let ((inhibit-read-only t)) ,@body)
      (current-buffer)))
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -86,6 +86,11 @@
   :group 'dashboard
   :type 'hook)
 
+(defcustom dashboard-before-initialize-hook nil
+  "Hook that is run before dashboard buffer is initialized."
+  :group 'dashboard
+  :type 'hook)
+
 (defcustom dashboard-hide-cursor nil
   "Whether to hide the cursor in the dashboard."
   :type 'boolean
@@ -440,6 +445,7 @@ Optional argument ARGS adviced function arguments."
   "Execute BODY in dashboard buffer."
   (declare (indent 0))
   `(with-current-buffer (get-buffer-create dashboard-buffer-name)
+     (run-hooks 'dashboard-before-initialize-hook)
      (let ((inhibit-read-only t)) ,@body)
      (current-buffer)))
 

--- a/dashboard.el
+++ b/dashboard.el
@@ -497,6 +497,7 @@ See `dashboard-item-generators' for all items available."
       (setq recentf-list (dashboard-subseq recentf-list dashboard-num-recents)))
     (dashboard--with-buffer
       (when (or dashboard-force-refresh (not (eq major-mode 'dashboard-mode)))
+        (run-hooks 'dashboard-before-initialize-hook)
         (erase-buffer)
         (setq dashboard--section-starts nil)
 


### PR DESCRIPTION
I've noticed that using dashboard-after-initialize-hook with solaire doesn't fix banner image background issue.
I found that this is because the banner is created before solaire is called.

The solution i found is making other hook that just run before dashboard buffer is created.

I wonder if this is a can a good idea or just run dashboard-after-initialize-hook in dashboard--with-buffer.

Also i've noticed moving solaire first in dashboard-startupify-list fix this too.
