### PR TITLE
Support for arguments in dashboard-startupify-list and add FAQ

### DIFF
--- a/FAQ.org
+++ b/FAQ.org
@@ -70,7 +70,7 @@ You can delete them from ~dashboard-startupify-list~.
 #+begin_src emacs-lisp
   (setq dashboard-startupify-list '(dashboard-insert-banner-title
                                     dashboard-insert-navigator
-                                    (dashboard-insert-newline . 2)
+                                    ,(dashboard-insert-newline 2)
                                     dashboard-insert-footer))
 #+end_src
 

--- a/FAQ.org
+++ b/FAQ.org
@@ -1,0 +1,97 @@
+* Frequently Asked Questions
+
+** /How can i hide modeline in dashboard?/
+
+You can add this to your config:
+  #+begin_src emacs-lisp
+  (add-hook 'dashboard-mode-hook (lambda () (setq-local mode-line-format nil)))
+  #+end_src
+  You can also use [[https://github.com/hlissner/emacs-hide-mode-line][hide-mode-line]]:
+#+begin_src elisp
+  (add-hook 'dashboard-mode-hook #'hide-mode-line-mode)
+  ;; Or for use-package
+  (use-package hide-mode-line
+    :hook (dashboard-mode . hide-mode-line-mode)
+    ...)
+#+end_src
+For doom-modeline users you may use this:
+#+begin_src elisp
+  (add-to-list 'doom-modeline-mode-alist '(dashboard-mode))
+#+end_src
+
+** /How can i use [[https://github.com/hlissner/emacs-solaire-mode][solaire-mode]] with dashboard?/
+
+Add this to your config:
+#+begin_src emacs-lisp
+  (add-hook 'dashboard-before-initialize-hook #'solaire-mode)
+  ;; Or if you prefer use-package
+  (use-package solaire-mode
+    :hook (dashboard-before-initialize . solaire-mode)
+    ...)
+#+end_src
+
+
+** /How can i add my custom widget?/
+
+To add your own custom widget is pretty easy, define your widget's callback function and add it to `dashboard-items` as such:
+#+BEGIN_SRC elisp
+  (defun dashboard-insert-custom (list-size)
+    (insert "Custom text"))
+  (add-to-list 'dashboard-item-generators  '(custom . dashboard-insert-custom))
+  (add-to-list 'dashboard-items '(custom) t)
+#+END_SRC
+
+If you want to add an icon to a custom widget, insert it with `dashboard-insert-heading` in your custom function:
+#+BEGIN_SRC elisp
+  ;; In this example, there is an icon but no shortcut
+  ;; see `dashboard-insert-heading' for more details.
+  (defun dashboard-insert-custom (list-size)
+    (dashboard-insert-heading "News:"
+                              nil
+                              (all-the-icons-faicon "newspaper-o"
+                                                    :height 1.2
+                                                    :v-adjust 0.0
+                                                    :face 'dashboard-heading))
+    (insert "\n")
+    (insert "    Custom text"))
+#+END_SRC
+
+
+** Items length is to high How can i change it
+You can change dashboard-items-default-length amount:
+#+BEGIN_SRC elisp
+  (setq dashboard-items-default-length 20)
+#+END_SRC
+
+
+** /I don't like banner, init info or even items, How can i delete them from dashboard?/
+
+You can delete them from ~dashboard-startupify-list~.
+#+begin_src emacs-lisp
+  (setq dashboard-startupify-list '(dashboard-insert-banner-title
+                                    dashboard-insert-navigator
+                                    (dashboard-insert-newline . 2)
+                                    dashboard-insert-footer))
+#+end_src
+
+** /How can i change my init message?/
+
+You can customize it like this:
+#+BEGIN_SRC elisp
+  (setq dashboard-init-info "This is an init message!")
+#+END_SRC
+
+** /How can i change footer messages?/
+
+You can customize it like this:
+#+BEGIN_SRC elisp
+  (setq dashboard-footer-messages '("Dashboard is pretty cool!"))
+#+END_SRC
+If you want to change its icon you may use this:
+#+BEGIN_SRC elisp
+  (setq dashboard-footer-icon (all-the-icons-octicon "dashboard"
+                                                     :height 1.1
+                                                     :v-adjust -0.05
+                                                     :face 'font-lock-keyword-face))
+#+END_SRC
+

--- a/FAQ.org
+++ b/FAQ.org
@@ -57,7 +57,7 @@ If you want to add an icon to a custom widget, insert it with `dashboard-insert-
 #+END_SRC
 
 
-** Items length is to high How can i change it
+** Items length is too high How can i change it
 You can change dashboard-items-default-length amount:
 #+BEGIN_SRC elisp
   (setq dashboard-items-default-length 20)

--- a/README.org
+++ b/README.org
@@ -276,16 +276,7 @@ To use it with [[https://github.com/hlissner/emacs-hide-mode-line][hide-mode-lin
 
 Or for doom-modeline users
 #+begin_src elisp
-  (setq doom-modeline-mode-alist
-     (delete (assoc 'dashboard-mode doom-modeline-mode-alist)
-             doom-modeline-mode-alist))
-  ;; Or for use-package
-  (use-package doom-modeline
-   :custom
-   (doom-modeline-mode-alist
-    (delete (assoc 'dashboard-mode doom-modeline-mode-alist)
-             doom-modeline-mode-alist))
-   ...)
+  (add-to-list 'doom-modeline-mode-alist '(dashboard-mode))
 #+end_src
 
 To use it with [[https://github.com/ericdanan/counsel-projectile][counsel-projectile]] or [[https://github.com/bbatsov/persp-projectile][persp-projectile]]

--- a/README.org
+++ b/README.org
@@ -167,32 +167,6 @@ To modify the widget heading name:
                                ("Agenda for the coming week:" . "Agenda:")))
 #+END_SRC
 
-The default length for each item.
-#+BEGIN_SRC elisp
-  (setq dashboard-items-default-length 20)
-#+END_SRC
-
-To add your own custom widget is pretty easy, define your widget's callback function and add it to `dashboard-items` as such:
-#+BEGIN_SRC elisp
-  (defun dashboard-insert-custom (list-size)
-    (insert "Custom text"))
-  (add-to-list 'dashboard-item-generators  '(custom . dashboard-insert-custom))
-  (add-to-list 'dashboard-items '(custom) t)
-#+END_SRC
-
-To add an icon to a custom widget, insert it with `dashboard-insert-heading` in your custom function.  In this example, there is an icon but no shortcut.
-#+BEGIN_SRC elisp
-  (defun dashboard-insert-custom (list-size)
-    (dashboard-insert-heading "News:"
-                              nil
-                              (all-the-icons-faicon "newspaper-o"
-                                                    :height 1.2
-                                                    :v-adjust 0.0
-                                                    :face 'dashboard-heading))
-    (insert "\n")
-    (insert "    Custom text"))
-#+END_SRC
-
 To use ~all-the-icons~ package:
 #+BEGIN_SRC emacs-lisp
   (setq dashboard-icon-type 'all-the-icons)  ; use `all-the-icons' package
@@ -240,44 +214,6 @@ To customize the buttons of the navigator like this:
             (lambda (&rest _) (browse-url "homepage")))
            ("⚑" nil "Show flags" (lambda (&rest _) (message "flag")) error))))
 #+END_SRC
-
-Also, the message can be customized like this:
-#+BEGIN_SRC elisp
-  (setq dashboard-init-info "This is an init message!")
-#+END_SRC
-
-To customize it and customize its icon;
-#+BEGIN_SRC elisp
-  (setq dashboard-footer-messages '("Dashboard is pretty cool!"))
-  (setq dashboard-footer-icon (all-the-icons-octicon "dashboard"
-                                                     :height 1.1
-                                                     :v-adjust -0.05
-                                                     :face 'font-lock-keyword-face))
-#+END_SRC
-
-To use it with [[https://github.com/hlissner/emacs-solaire-mode][solaire-mode]]:
-#+begin_src emacs-lisp
-  (add-hook 'dashboard-before-initialize-hook #'solaire-mode)
-#+end_src
-
-Or for use-package users
-#+begin_src emacs-lisp
-  :hook (dashboard-before-initialize . solaire-mode)
-#+end_src
-
-To use it with [[https://github.com/hlissner/emacs-hide-mode-line][hide-mode-line]]
-#+begin_src elisp
-  (add-hook 'dashboard-mode #'hide-mode-line-mode)
-  ;; Or for use-package
-  (use-package hide-mode-line
-    :hook (dashboard-mode . hide-mode-line-mode)
-    ...)
-#+end_src
-
-Or for doom-modeline users
-#+begin_src elisp
-  (add-to-list 'doom-modeline-mode-alist '(dashboard-mode))
-#+end_src
 
 To use it with [[https://github.com/ericdanan/counsel-projectile][counsel-projectile]] or [[https://github.com/bbatsov/persp-projectile][persp-projectile]]
 

--- a/README.org
+++ b/README.org
@@ -265,6 +265,29 @@ Or for use-package users
   :hook (dashboard-before-initialize . solaire-mode)
 #+end_src
 
+To use it with [[https://github.com/hlissner/emacs-hide-mode-line][hide-mode-line]]
+#+begin_src elisp
+  (add-hook 'dashboard-mode #'hide-mode-line-mode)
+  ;; Or for use-package
+  (use-package hide-mode-line
+    :hook (dashboard-mode . hide-mode-line-mode)
+    ...)
+#+end_src
+
+Or for doom-modeline users
+#+begin_src elisp
+  (setq doom-modeline-mode-alist
+     (delete (assoc 'dashboard-mode doom-modeline-mode-alist)
+             doom-modeline-mode-alist))
+  ;; Or for use-package
+  (use-package doom-modeline
+   :custom
+   (doom-modeline-mode-alist
+    (delete (assoc 'dashboard-mode doom-modeline-mode-alist)
+             doom-modeline-mode-alist))
+   ...)
+#+end_src
+
 To use it with [[https://github.com/ericdanan/counsel-projectile][counsel-projectile]] or [[https://github.com/bbatsov/persp-projectile][persp-projectile]]
 
 #+begin_src elisp

--- a/README.org
+++ b/README.org
@@ -290,6 +290,8 @@ receives the tags directly from ~org-get-tags~. By default
 tags set the variable to ~ignore~: ~(setq dashboard-agenda-tags-format 'ignore)~
 or to ~nil~.
 
+** [[./FAQ.org][FAQ]]
+
 ** Faces
 
 It is possible to customize Dashboard's appearance using the following faces:

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -601,10 +601,10 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   "Insert a page break line in dashboard buffer."
   (dashboard-append dashboard-page-separator))
 
-(defun dashboard-insert-newline (&optional n)
-  "Insert N times of newlines."
-  (dotimes (_ (or n 1))
-    (insert "\n")))
+(defun dashboard-insert-newline (&optional times)
+  "When called without an argument, insert a newline.
+When called with TIMES return a function that insert TIMES number of newlines."
+  (insert (make-string (or times 1) (string-to-char "\n") t)))
 
 (defun dashboard-insert-heading (heading &optional shortcut icon)
   "Insert a widget HEADING in dashboard buffer, adding SHORTCUT, ICON if provided."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -607,7 +607,7 @@ When called with TIMES return a function that insert TIMES number of newlines."
   (if times
       (lambda ()
         (insert (make-string times (string-to-char "\n") t)))
-    (insert "\n"))
+    (insert "\n")))
 
 (defun dashboard-insert-heading (heading &optional shortcut icon)
   "Insert a widget HEADING in dashboard buffer, adding SHORTCUT, ICON if provided."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -413,7 +413,7 @@ If nil it is disabled.  Possible values for list-type are:
 `recents' `bookmarks' `projects' `agenda' `registers'."
   :type '(repeat (choice
                   symbol
-                  (cons symbol number)))
+                  (cons symbol integer)))
   :group 'dashboard)
 
 (defcustom dashboard-item-shortcuts

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -604,7 +604,10 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
 (defun dashboard-insert-newline (&optional times)
   "When called without an argument, insert a newline.
 When called with TIMES return a function that insert TIMES number of newlines."
-  (insert (make-string (or times 1) (string-to-char "\n") t)))
+  (if times
+      (lambda ()
+        (insert (make-string times (string-to-char "\n") t)))
+    (insert "\n"))
 
 (defun dashboard-insert-heading (heading &optional shortcut icon)
   "Insert a widget HEADING in dashboard buffer, adding SHORTCUT, ICON if provided."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -411,7 +411,9 @@ installed."
 Will be of the form `(list-type . list-size)'.
 If nil it is disabled.  Possible values for list-type are:
 `recents' `bookmarks' `projects' `agenda' `registers'."
-  :type  '(repeat (alist :key-type symbol :value-type integer))
+  :type '(repeat (choice
+                  symbol
+                  (cons symbol number)))
   :group 'dashboard)
 
 (defcustom dashboard-item-shortcuts

--- a/dashboard.el
+++ b/dashboard.el
@@ -507,6 +507,7 @@ See `dashboard-item-generators' for all items available."
 
         (mapc (lambda (entry)
                 (if (and (listp entry)
+                         (not (eq (car entry) 'closure))
                          (not (eq (car entry) 'lambda)))
                     (apply (car entry) (cdr entry))
                   (funcall entry)))

--- a/dashboard.el
+++ b/dashboard.el
@@ -505,10 +505,10 @@ See `dashboard-item-generators' for all items available."
         (erase-buffer)
         (setq dashboard--section-starts nil)
 
-        (mapc (lambda (list)
+        (mapc (lambda (entry)
                 (if (listp entry)
                     (apply (car entry) (cdr entry))
-                  (funcall fn args)))
+                  (funcall entry)))
               dashboard-startupify-list)
 
         (when dashboard-vertically-center-content

--- a/dashboard.el
+++ b/dashboard.el
@@ -506,7 +506,8 @@ See `dashboard-item-generators' for all items available."
         (setq dashboard--section-starts nil)
 
         (mapc (lambda (entry)
-                (if (listp entry)
+                (if (and (listp entry)
+                         (not (eq (car entry) 'lambda)))
                     (apply (car entry) (cdr entry))
                   (funcall entry)))
               dashboard-startupify-list)

--- a/dashboard.el
+++ b/dashboard.el
@@ -143,10 +143,15 @@ Avalaible functions:
   `dashboard-insert-items'
   `dashboard-insert-footer'
 
-You can also add your custom function or a lambda to the list.
+It must be a function or a cons cell where specify function and
+its arg.
+
+Also you can add your custom function or a lambda to the list.
 example:
  (lambda () (delete-char -1))"
-  :type '(repeat function)
+  :type '(repeat (choice
+                  function
+                  (cons function sexp)))
   :group 'dashboard)
 
 (defcustom dashboard-navigation-cycle nil
@@ -500,8 +505,13 @@ See `dashboard-item-generators' for all items available."
         (erase-buffer)
         (setq dashboard--section-starts nil)
 
-        (mapc (lambda (fn)
-                (funcall fn))
+        (mapc (lambda (list)
+                (if-let* (((consp list))
+                          (fn (car list))
+                          (args (cdr list))
+                          ((not (eq fn 'lambda))))
+                    (funcall fn args)
+                  (funcall list)))
               dashboard-startupify-list)
 
         (when dashboard-vertically-center-content

--- a/dashboard.el
+++ b/dashboard.el
@@ -506,12 +506,9 @@ See `dashboard-item-generators' for all items available."
         (setq dashboard--section-starts nil)
 
         (mapc (lambda (list)
-                (if-let* (((consp list))
-                          (fn (car list))
-                          (args (cdr list))
-                          ((not (eq fn 'lambda))))
-                    (funcall fn args)
-                  (funcall list)))
+                (if (listp entry)
+                    (apply (car entry) (cdr entry))
+                  (funcall fn args)))
               dashboard-startupify-list)
 
         (when dashboard-vertically-center-content


### PR DESCRIPTION
This patch adds optional support for insert arguments into dashboard-startupify-list, this allow insert amount newlines in dashboard-insert-newline, and add into README how to hide modeline.

Also this updates dashboard-items for optionally insert list size.