### PR TITLE
Fix custom type for dashboard-heading-icons

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -193,7 +193,7 @@ The value can be one of: `all-the-icons', `nerd-icons'."
 Will be of the form `(list-type . icon-name-string)`.
 If nil it is disabled.  Possible values for list-type are:
 `recents' `bookmarks' `projects' `agenda' `registers'"
-  :type  '(repeat (alist :key-type symbol :value-type string))
+  :type  '(alist :key-type symbol :value-type string)
   :group 'dashboard)
 
 (defcustom dashboard-heading-icon-height 1.2


### PR DESCRIPTION
The previous type is wrong, as it's for a list of alists, rather than a single alist.