### PR TITLE
Fix vertical offset for centering

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -516,7 +516,9 @@ See `dashboard-item-generators' for all items available."
 
         (when dashboard-vertically-center-content
           (goto-char (point-min))
-          (when-let* ((content-height (cdr (window-absolute-pixel-position (point-max))))
+          (when-let* ((start-height (cdr (window-absolute-pixel-position (point-min))))
+                      (end-height (cdr (window-absolute-pixel-position (point-max))))
+                      (content-height (- end-height start-height))
                       (vertical-padding (floor (/ (- (window-pixel-height) content-height) 2)))
                       ((> vertical-padding 0))
                       (vertical-lines (1- (floor (/ vertical-padding (line-pixel-height)))))


### PR DESCRIPTION
When moving my frame without resizing I expect the logic for vertical centering to give the same result before and after. This currently does not seem to be the case. 

Try setting `dashboard-vertically-center-content` to `t` and then open a new frame. The resulting height of the dashboard depends on the y-coordinate of the frame because `window-absolute-pixel-position` does not give coordinates relative to the frame.

I work around this by subtracting the height "above" my frame. Note that `(point-min)` may not be visible in the frame. Then `(window-absolute-pixel-position (point-min))` evaluates to `nil` which stops the vertical alignment. This seems fine to me as in this case the content does not fit inside the frame anyway.

I noticed this while Emacs was running with XWayland, but I think this applies to X11 aswell. I did not test this with a native Wayland frame.