### PR TITLE
feat: Parameters for file icon height and v-adjust

### DIFF
--- a/README.org
+++ b/README.org
@@ -196,6 +196,14 @@ To modify heading icons with another icon from nerd-icons octicons:
                                     (bookmarks . "nf-oct-book")))
 #+END_SRC
 
+To modify the icon height or vertical adjust:
+#+BEGIN_SRC emacs-lisp
+  (setq dashboard-icon-file-height 1.75)
+  (setq dashboard-icon-file-v-adjust -0.125)
+  (setq dashboard-heading-icon-height 1.75)
+  (setq dashboard-heading-icon-v-adjust -0.125)
+#+END_SRC
+
 To customize the buttons of the navigator like this:
 #+BEGIN_SRC emacs-lisp
   ;; Format: "(icon title help action face prefix suffix)"

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -903,7 +903,7 @@ Argument IMAGE-PATH path to the image."
                                           (not (string-equal icon ""))
                                           (not (string-equal title "")))
                                  (propertize " " 'face `(:inherit (variable-pitch
-                                                                  ,face))))
+                                                                   ,face))))
                                (when title (propertize title 'face face)))
                          :help-echo help
                          :action action

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -207,12 +207,12 @@ If nil it is disabled.  Possible values for list-type are:
   :type 'float
   :group 'dashboard)
 
-(defcustom dashboard-file-icon-height 1.0
+(defcustom dashboard-icon-file-height 1.0
   "The height of the file icons."
   :type 'float
   :group 'dashboard)
 
-(defcustom dashboard-file-icon-v-adjust -0.05
+(defcustom dashboard-icon-file-v-adjust -0.05
   "The v-adjust of the file icons."
   :type 'float
   :group 'dashboard)
@@ -964,8 +964,8 @@ to widget creation."
                             ((file-remote-p path)
                              dashboard-remote-path-icon)
                             (t (dashboard-icon-for-file (file-name-nondirectory path)
-                                                        :height dashboard-file-icon-height
-                                                        :v-adjust dashboard-file-icon-v-adjust))))))
+                                                        :height dashboard-icon-file-height
+                                                        :v-adjust dashboard-icon-file-v-adjust))))))
               (setq tag (concat icon " " ,@rest))))
 
           (widget-create 'item

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -207,6 +207,16 @@ If nil it is disabled.  Possible values for list-type are:
   :type 'float
   :group 'dashboard)
 
+(defcustom dashboard-file-icon-height 1.0
+  "The height of the file icons."
+  :type 'float
+  :group 'dashboard)
+
+(defcustom dashboard-file-icon-v-adjust -0.05
+  "The v-adjust of the file icons."
+  :type 'float
+  :group 'dashboard)
+
 (defcustom dashboard-agenda-item-icon
   (pcase dashboard-icon-type
     ('all-the-icons (all-the-icons-octicon "primitive-dot" :height 1.0 :v-adjust 0.01))
@@ -954,7 +964,8 @@ to widget creation."
                             ((file-remote-p path)
                              dashboard-remote-path-icon)
                             (t (dashboard-icon-for-file (file-name-nondirectory path)
-                                                        :v-adjust -0.05))))))
+                                                        :height dashboard-file-icon-height
+                                                        :v-adjust dashboard-file-icon-v-adjust))))))
               (setq tag (concat icon " " ,@rest))))
 
           (widget-create 'item

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -956,7 +956,9 @@ to widget creation."
             (let* ((path (car (last (split-string ,@rest " - "))))
                    (icon (if (and (not (file-remote-p path))
                                   (file-directory-p path))
-                             (dashboard-icon-for-dir path nil "")
+                             (dashboard-icon-for-dir path
+                                                     :height dashboard-icon-file-height
+                                                     :v-adjust dashboard-icon-file-v-adjust)
                            (cond
                             ((or (string-equal ,section-name "Agenda for today:")
                                  (string-equal ,section-name "Agenda for the coming week:"))


### PR DESCRIPTION
This PR adds support for tweaking the height and v-adjust of file icons. It aligns with the existing parameters
`dashboard-heading-icon-height` and `dashboard-heading-icon-v-adjust` which work similarly for heading icons.

Defaults are set to the previous defaults.

Let me know if there are any changes needed. :slightly_smiling_face: 