### PR TITLE
Fix #566 to show "installed packages" instead of "loaded packages".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Support for random banners (#510)
 * Support for random footer icon (#519)
 * feat: Parameters for file icon `height` and `v-adjust` (#546)
+* fix: Show `installed packages` instead of `loaded packages`. (#570)
 
 ## 1.8.0
 > Released Jul 26, 2023

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -890,9 +890,13 @@ Argument IMAGE-PATH path to the image."
 ;;; Initialize info
 (defun dashboard-insert-init-info ()
   "Insert init info."
-  (let ((init-info (if (functionp dashboard-init-info)
-                       (funcall dashboard-init-info)
-                     dashboard-init-info)))
+  (let ((init-info (cond ((stringp dashboard-init-info)
+                          dashboard-init-info)
+                         ((functionp dashboard-init-info)
+                          (funcall dashboard-init-info))
+                         (t
+                          (user-error "Unknown init info type (%s): %s"
+                                      (type-of init-info) init-info)))))
     (dashboard-insert-center
      (propertize init-info 'face 'font-lock-comment-face))))
 

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -288,7 +288,12 @@ Example:
                                        (const nil)))))
   :group 'dashboard)
 
-(defun dashboard-init-info ()
+(defcustom dashboard-init-info #'dashboard-init--info
+  "Custom function that must return a string to place instead of init-info."
+  :type 'function
+  :group 'dashboard)
+
+(defun dashboard-init--info ()
   "Init info with packages loaded and init time.
 Supported package managers are: package.el, straight.el and elpaca.el."
   (let* ((package-count (or (and (bound-and-true-p package-alist)
@@ -881,7 +886,7 @@ Argument IMAGE-PATH path to the image."
 ;;; Initialize info
 (defun dashboard-insert-init-info ()
   "Insert init info."
-  (let ((init-info (dashboard-init-info)))
+  (let ((init-info (funcall dashboard-init-info)))
     (dashboard-insert-center (propertize init-info 'face 'font-lock-comment-face))))
 
 (defun dashboard-insert-navigator ()

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -309,12 +309,16 @@ Supported package managers are: package.el, straight.el and elpaca.el."
     (+ package-count straight-count elpaca-count)))
 
 
-(defun dashboard-init--info (init-time packages-count)
-  "Format init message depending on PACKAGES-COUNT and includes INIT-TIME."
-  (if (zerop packages-count)
+(defun dashboard-init--info ()
+  "Format init message.
+Use `dashboard-init--time' and `dashboard-init--package-count' to generate
+init message."
+  (let ((init-time (dashboard-init--time))
+        (packages-count (dashboard-init--packages-count)))
+    (if (zerop packages-count)
       (format "Emacs started in %s" init-time)
     (format "%d packages installed. Emacs started in %s."
-            packages-count init-time)))
+            packages-count init-time))))
 
 (defcustom dashboard-display-icons-p #'display-graphic-p
   "Predicate to determine whether dashboard should show icons.
@@ -886,10 +890,11 @@ Argument IMAGE-PATH path to the image."
 ;;; Initialize info
 (defun dashboard-insert-init-info ()
   "Insert init info."
-  (let* ((init-time (dashboard-init--time))
-         (packages-count (dashboard-init--packages-count))
-         (init-info (funcall dashboard-init-info init-time packages-count)))
-    (dashboard-insert-center (propertize init-info 'face 'font-lock-comment-face))))
+  (let ((init-info (if (functionp dashboard-init-info)
+                       (funcall dashboard-init-info)
+                     dashboard-init-info)))
+    (dashboard-insert-center
+     (propertize init-info 'face 'font-lock-comment-face))))
 
 (defun dashboard-insert-navigator ()
   "Insert Navigator of the dashboard."

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -316,9 +316,9 @@ init message."
   (let ((init-time (dashboard-init--time))
         (packages-count (dashboard-init--packages-count)))
     (if (zerop packages-count)
-      (format "Emacs started in %s" init-time)
-    (format "%d packages installed. Emacs started in %s."
-            packages-count init-time))))
+        (format "Emacs started in %s" init-time)
+      (format "%d packages installed. Emacs started in %s."
+              packages-count init-time))))
 
 (defcustom dashboard-display-icons-p #'display-graphic-p
   "Predicate to determine whether dashboard should show icons.

--- a/docs/FAQ.org
+++ b/docs/FAQ.org
@@ -92,11 +92,11 @@ You can delete them from ~dashboard-startupify-list~.
                                     dashboard-insert-footer))
 #+end_src
 
-* /How can I change my init message?/
+* /How can I change my welcome message?/
 
 You can customize it like this:
 #+BEGIN_SRC elisp
-  (setq dashboard-init-info "This is an init message!")
+  (setq dashboard-banner-logo-title "This is an init message!")
 #+END_SRC
 
 * /How can I change footer messages?/
@@ -113,4 +113,3 @@ If you want to change its icon you may use this:
                                                      :face 'font-lock-keyword-face))
 Also it can be a string list for display random footer icons.
 #+END_SRC
-

--- a/docs/FAQ.org
+++ b/docs/FAQ.org
@@ -92,11 +92,11 @@ You can delete them from ~dashboard-startupify-list~.
                                     dashboard-insert-footer))
 #+end_src
 
-* /How can I change my welcome message?/
+* /How can I change my init message?/
 
 You can customize it like this:
 #+BEGIN_SRC elisp
-  (setq dashboard-banner-logo-title "This is an init message!")
+  (setq dashboard-init-info "This is an init message!")
 #+END_SRC
 
 * /How can I change footer messages?/

--- a/docs/variables-and-functions.org
+++ b/docs/variables-and-functions.org
@@ -7,6 +7,7 @@ These are the variables available to users out of the box:
 | `dashboard-startup-banner`         | Define the banner at the top of the dashboard.                                   | `'official`, path to an image, or `nil`                                                                |
 | `dashboard-banner-logo-title`      | Text to display below the banner.                                                | Any string (e.g., `"Welcome to Emacs!"`)                                                               |
 | `dashboard-center-content`         | Center the content horizontally.                                                 | `t`: Enable, `nil`: Disable                                                                             |
+| `dashboard-init-info`              | Custom variable, could be a string or a function that returns a string           | default: `dashboard-init--info`                                                                   |
 | `dashboard-vertically-center-content` | Center the content vertically.                                                  | `t`: Enable, `nil`: Disable                                                                             |
 | `dashboard-page-separator`         | String used to separate sections in the buffer.                                  | Any string (default: `"\n\n"`)                                                                         |
 | `dashboard-set-heading-icons`      | Show icons next to section headings.                                             | `t`: Enable, `nil`: Disable                                                                             |
@@ -73,6 +74,9 @@ These are the variables available to users out of the box:
 | `dashboard-cycle-current-section-forward` | Cycle forward through entries in the current section.                | None                    |
 | `dashboard-cycle-current-section-backward` | Cycle backward through entries in the current section.               | None                    |
 | `dashboard-remove-item-under`       | Remove the current item from the dashboard.                           | None                    |
+| `dashboard-init--info`              | Build a string with the init-time and package-count                       |                             |
+| `dashboard-init--time`              | Same as `emacs-init-time` and support elpaca init time                    |                             |
+| `dashboard-init--package-count      | Return the number of installed packages                                   |                             |
 | `dashboard-insert-items`            | Insert all configured dashboard items into the buffer.                | None                    |
 | `dashboard-insert-banner`           | Insert the banner into the dashboard buffer.                          | None                    |
 | `dashboard-insert-newline`          | Insert a newline in the dashboard buffer.                             | None                    |


### PR DESCRIPTION
Also, change defcustom to defun in `dashboard-init-info`, this remove the possibility to customize a text when `dashboard-insert-init-info` but there is `dashboard-banner-logo-title` which is more suitable for that purpose.