### PR TITLE
Fix agenda properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ EASK ?= eask
 
 .PHONY: clean checkdoc lint package install compile test
 
-ci: clean package install compile
+ci: clean package install checkdoc compile
 
 package:
 	@echo "Packaging..."

--- a/README.org
+++ b/README.org
@@ -263,7 +263,7 @@ To show agenda for the upcoming seven days set the variable ~dashboard-week-agen
   (setq dashboard-week-agenda t)
 #+END_SRC
 
-By default org-agenda entries are filter by time, only showing those
+By default, org-agenda entries are filtered by time, only showing those
 task with ~DEADLINE~, ~SCHEDULE-TIME~ or ~TIMESTAMP~ . To show all agenda entries
 (except ~DONE~)
 
@@ -308,7 +308,7 @@ respect [[https://orgmode.org/worg/doc.html#org-agenda-todo-keyword-format][org-
 
 To customize the tags format there is a variable
 ~dashboard-agenda-tags-format~. This variable could be any function that
-receives the tags directly from ~org-get-tags~. By default
+receives the tags directly from ~org-get-tags~. By default,
 ~dashboard-agenda-tags-format~ is set to ~identity~. To hide the
 tags set the variable to ~ignore~: ~(setq dashboard-agenda-tags-format 'ignore)~
 or to ~nil~.

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -274,7 +274,7 @@ nerd-icons or (all-the-icons-faicon \"newspaper-o\") using all-the-icons."
   :group 'dashboard)
 
 (defcustom dashboard-banner-ascii "EMACS"
-  "String to be shown in place of the startup banner
+  "String to be shown in place of the startup banner.
 if `dashboard-startup-banner' is set to `ascii'."
   :type 'string
   :group 'dashboard)
@@ -631,7 +631,7 @@ Set to nil for unbounded."
 ;; TODO: Use function `string-pixel-width' after 29.1
 (defun dashboard-string-pixel-width (str)
   "Return the width of STR in pixels."
-  (if (fboundp #'string-pixel-width)
+  (if (fboundp 'string-pixel-width)
       (string-pixel-width str)
     (require 'shr)
     (shr-string-pixel-width str)))
@@ -1431,8 +1431,8 @@ Return function that returns a list of projects."
      (when dashboard-remove-missing-entry
        (dashboard-mute-apply
          (ignore-errors
-           (dashboard-funcall-fboundp #'project-forget-zombie-projects))))
-     (project-known-project-roots))
+           (dashboard-funcall-fboundp 'project-forget-zombie-projects))))
+     (dashboard-funcall-fboundp 'project-known-project-roots))
     (t
      (display-warning '(dashboard)
                       "Invalid value for `dashboard-projects-backend'"

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -27,6 +27,7 @@
 (declare-function all-the-icons-icon-for-file "ext:all-the-icons.el")
 (declare-function all-the-icons-fileicon "ext:data-fileicons.el")
 (declare-function all-the-icons-octicon "ext:data-octicons.el")
+(declare-function ansi-color-apply-on-region "ext:ansi-color.el")
 (declare-function nerd-icons-icon-for-dir "ext:nerd-icons.el")
 (declare-function nerd-icons-icon-for-file "ext:nerd-icons.el")
 (declare-function nerd-icons-sucicon "ext:nerd-icons.el")
@@ -1010,40 +1011,39 @@ Return a space if icon is not found."
 ;;; Section list
 
 (defmacro dashboard-insert-section-list (section-name list action &rest rest)
-  "Insert into SECTION-NAME a LIST of items, expanding ACTION and passing REST
-to widget creation."
+  "Insert into SECTION-NAME a LIST of items, expanding ACTION.
+REST is for widget creation."
   `(when (car ,list)
      (mapc
-	  (lambda (el)
-		(let* ((tag ,@rest)
+      (lambda (el)
+        (let* ((tag ,@rest)
                (item tag))
-		  (insert "\n")
-		  (insert (spaces-string (or standard-indent tab-width 4)))
+          (insert "\n")
+          (insert (spaces-string (or standard-indent tab-width 4)))
 
-		  (when (and (dashboard-display-icons-p)
-					 dashboard-set-file-icons)
-			(let* ((path (get-text-property 0 'dashboard-path item))
-				   (icon (cond
-						  ((or (string-equal ,section-name "Agenda for today:")
-							   (string-equal ,section-name "Agenda for the coming
-  week:"))
-						   dashboard-agenda-item-icon)
-						  ((and (stringp path)
-								(file-remote-p path))
-						   dashboard-remote-path-icon)
-						  ((and (stringp path)
-								(file-directory-p path))
-						   (dashboard-icon-for-dir
-							path
-							:height dashboard-icon-file-height
-							:v-adjust dashboard-icon-file-v-adjust))
-						  ((stringp path)
-						   (dashboard-icon-for-file
-							(file-name-nondirectory path)
-							:height dashboard-icon-file-height
-							:v-adjust dashboard-icon-file-v-adjust))
-						  (t ""))))
-			  (setq tag (concat icon " " item))))
+          (when (and (dashboard-display-icons-p)
+                     dashboard-set-file-icons)
+            (let* ((path (get-text-property 0 'dashboard-path item))
+                   (icon (cond
+                          ((or (string-equal ,section-name "Agenda for today:")
+                               (string-equal ,section-name "Agenda for the coming week:"))
+                           dashboard-agenda-item-icon)
+                          ((and (stringp path)
+                                (file-remote-p path))
+                           dashboard-remote-path-icon)
+                          ((and (stringp path)
+                                (file-directory-p path))
+                           (dashboard-icon-for-dir
+                            path
+                            :height dashboard-icon-file-height
+                            :v-adjust dashboard-icon-file-v-adjust))
+                          ((stringp path)
+                           (dashboard-icon-for-file
+                            (file-name-nondirectory path)
+                            :height dashboard-icon-file-height
+                            :v-adjust dashboard-icon-file-v-adjust))
+                          (t ""))))
+              (setq tag (concat icon " " item))))
 
           (widget-create 'item
                          :tag tag

--- a/dashboard.el
+++ b/dashboard.el
@@ -425,7 +425,7 @@ Optional argument ARGS adviced function arguments."
     (dashboard-mute-apply
       (cl-case dashboard-projects-backend
         (`projectile (projectile-remove-known-project path))
-        (`project-el (project-forget-projects-under path))))))
+        (`project-el (dashboard-funcall-fboundp 'project-forget-projects-under path))))))
 
 (defun dashboard-remove-item-bookmarks ()
   "Remove a bookmarks from `bookmark-alist'."


### PR DESCRIPTION
Due to the indentation in we introduce a bug where icons and properties were missing from agenda items. 
This fix the issue and add `checkout` to the `ci` workflow. I want to add `easklint packages`, but it fails because `recentf-list` variable, so it's time to refactor the recents section before adding the linter to the workflow.