### PR TITLE
add ansi-color to be required

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -18,7 +18,6 @@
 (require 'mule-util)
 (require 'rect)
 (require 'subr-x)
-(require 'ansi-color)
 
 ;;
 ;;; Externals
@@ -65,6 +64,7 @@
 (declare-function org-time-string-to-time "ext:org.el")
 (declare-function org-today "ext:org.el")
 (declare-function recentf-cleanup "ext:recentf.el")
+(declare-function ansi-color-apply-on-region "ext:ansi-color")
 (defvar dashboard-mode-map)
 (defvar org-level-faces)
 (defvar org-agenda-new-buffers)

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -18,6 +18,7 @@
 (require 'mule-util)
 (require 'rect)
 (require 'subr-x)
+(require 'ansi-color)
 
 ;;
 ;;; Externals


### PR DESCRIPTION
Recently when I load my Emacs I get the following warning:

```
⛔ Warning` (native-compiler): dashboard-widgets.el:875:12: Warning: the function ‘ansi-color-apply-on-region’ is not known to be defined.
```

Which refers to this line:

https://github.com/emacs-dashboard/dashboard/blob/f28b8e1c5f895c1dbf908a0550303a1de37fa259/dashboard-widgets.el#L875

The issue mostly happens when running Emacs daemon and then connect an emacsclient to it. Also the issue does not always happen.

The `ansi-color-apply-on-region` is a natively compiled function defined in `ansi-color.el.gz`. So I think the problem is some sort of race condition, that if `dashboard.el` is loaded before the `ansi-color.el`, the error occurs. 

I managed to solve it permanently (as far as my testing goes) using the following:

```lisp
(use-package dashboard
  :ensure t
  :after (:all ansi-color nerd-icons)
  ...
)
```

Considering this ad-hoc fix, I added `(require 'ansi-color)` to the `dashboard-widgets.el` to make sure `ansi-color' is always loaded before we use its functions.